### PR TITLE
feat: export migration scripts

### DIFF
--- a/packages/data-model/index.ts
+++ b/packages/data-model/index.ts
@@ -1,1 +1,2 @@
+export * from './src/functions/migrate.js';
 export * from './src/models/index.js';

--- a/packages/data-model/index.ts
+++ b/packages/data-model/index.ts
@@ -1,2 +1,3 @@
+export * from './src/config/db.js';
 export * from './src/functions/migrate.js';
-export * from './src/models/index.js';
+export * as models from './src/models/index.js';

--- a/packages/data-model/package.json
+++ b/packages/data-model/package.json
@@ -23,6 +23,10 @@
 	"files": [
 		"dist/"
 	],
+	"exports": {
+		".": "./index.js",
+		"./models": "./src/models/index.js"
+	},
 	"license": "AGPL-3.0-or-later",
 	"repository": {
 		"type": "git",

--- a/packages/data-model/package.json
+++ b/packages/data-model/package.json
@@ -9,8 +9,9 @@
 		"\n=====================  Build  =================": "",
 		"build:compile": "rimraf dist && tsc",
 		"build:migration": "drizzle-kit generate:pg --config=drizzle.config.ts",
+		"build:migration:copy": "copyfiles migrations/** migrations/**/**  dist/",
 		"build:dbml": "tsx scripts/dbmlGenerator.ts",
-		"build:all": "pnpm build:compile && pnpm build:migration && pnpm build:dbml",
+		"build:all": "pnpm build:compile && pnpm build:migration && pnpm build:migration:copy && pnpm build:dbml",
 		"\n==============  Dev environment  ==============": "",
 		"db:migrate:dev": "tsx scripts/migrate.ts",
 		"\n====  Production environtment (compiled)  =====": "",
@@ -40,6 +41,7 @@
 	},
 	"dependencies": {
 		"@overture-stack/lectern-client": "2.0.0-beta.3",
+		"copyfiles": "^2.4.1",
 		"dotenv": "^16.4.5",
 		"drizzle-orm": "^0.29.5",
 		"pg": "^8.12.0"

--- a/packages/data-model/scripts/migrate.ts
+++ b/packages/data-model/scripts/migrate.ts
@@ -1,7 +1,26 @@
+import 'dotenv/config';
+
+import type { DbConfig } from '../src/config/db.js';
 import { migrate } from '../src/functions/migrate.js';
 
+const getRequiredConfig = (name: string) => {
+	const value = process.env[name];
+	if (!value) {
+		throw new Error(`No Environment Variable provided for required configuration parameter '${name}'`);
+	}
+	return value;
+};
+
+const config: DbConfig = {
+	host: getRequiredConfig('DB_HOST'),
+	database: getRequiredConfig('DB_NAME'),
+	password: getRequiredConfig('DB_PASSWORD'),
+	port: Number(getRequiredConfig('DB_PORT')),
+	user: getRequiredConfig('DB_USER'),
+};
+
 // Run if executed as a CLI
-migrate().catch((err) => {
+migrate(config).catch((err) => {
 	console.error(err);
 	process.exit(1);
 });

--- a/packages/data-model/scripts/migrate.ts
+++ b/packages/data-model/scripts/migrate.ts
@@ -1,34 +1,7 @@
-import 'dotenv/config';
+import { migrate } from '../src/functions/migrate.js';
 
-import { drizzle } from 'drizzle-orm/node-postgres';
-import { migrate } from 'drizzle-orm/node-postgres/migrator';
-import pg from 'pg';
-
-const getRequiredConfig = (name: string) => {
-	const value = process.env[name];
-	if (!value) {
-		throw new Error(`No Environment Variable provided for required configuration parameter '${name}'`);
-	}
-	return value;
-};
-
-async function main() {
-	console.log('Running your migrations...');
-
-	const sql = new pg.Pool({
-		host: getRequiredConfig('DB_HOST'),
-		database: getRequiredConfig('DB_NAME'),
-		password: getRequiredConfig('DB_PASSWORD'),
-		port: Number(getRequiredConfig('DB_PORT')),
-		user: getRequiredConfig('DB_USER'),
-	});
-	const db = drizzle(sql);
-	await migrate(db, { migrationsFolder: 'migrations' });
-	await sql.end();
-	console.log('Woohoo! Migrations completed!');
-}
-
-main().catch((err) => {
+// Run if executed as a CLI
+migrate().catch((err) => {
 	console.error(err);
 	process.exit(1);
 });

--- a/packages/data-model/src/config/db.ts
+++ b/packages/data-model/src/config/db.ts
@@ -1,0 +1,7 @@
+export type DbConfig = {
+	host: string;
+	port: number;
+	database: string;
+	user: string;
+	password: string;
+};

--- a/packages/data-model/src/functions/migrate.ts
+++ b/packages/data-model/src/functions/migrate.ts
@@ -1,0 +1,36 @@
+import 'dotenv/config';
+
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { migrate as migrator } from 'drizzle-orm/node-postgres/migrator';
+import path from 'path';
+import pg from 'pg';
+import { fileURLToPath } from 'url';
+
+const getRequiredConfig = (name: string) => {
+	const value = process.env[name];
+	if (!value) {
+		throw new Error(`No Environment Variable provided for required configuration parameter '${name}'`);
+	}
+	return value;
+};
+
+export async function migrate() {
+	console.log('Running your migrations...');
+
+	const sql = new pg.Pool({
+		host: getRequiredConfig('DB_HOST'),
+		database: getRequiredConfig('DB_NAME'),
+		password: getRequiredConfig('DB_PASSWORD'),
+		port: Number(getRequiredConfig('DB_PORT')),
+		user: getRequiredConfig('DB_USER'),
+	});
+	const db = drizzle(sql);
+
+	const currentDir = fileURLToPath(new URL('.', import.meta.url));
+
+	const migrationsFolder = path.join(currentDir, '..', '..', 'migrations');
+
+	await migrator(db, { migrationsFolder: migrationsFolder });
+	await sql.end();
+	console.log('Woohoo! Migrations completed!');
+}

--- a/packages/data-model/src/functions/migrate.ts
+++ b/packages/data-model/src/functions/migrate.ts
@@ -1,28 +1,20 @@
-import 'dotenv/config';
-
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { migrate as migrator } from 'drizzle-orm/node-postgres/migrator';
 import path from 'path';
 import pg from 'pg';
 import { fileURLToPath } from 'url';
 
-const getRequiredConfig = (name: string) => {
-	const value = process.env[name];
-	if (!value) {
-		throw new Error(`No Environment Variable provided for required configuration parameter '${name}'`);
-	}
-	return value;
-};
+import type { DbConfig } from '../config/db.js';
 
-export async function migrate() {
+export async function migrate(config: DbConfig) {
 	console.log('Running your migrations...');
 
 	const sql = new pg.Pool({
-		host: getRequiredConfig('DB_HOST'),
-		database: getRequiredConfig('DB_NAME'),
-		password: getRequiredConfig('DB_PASSWORD'),
-		port: Number(getRequiredConfig('DB_PORT')),
-		user: getRequiredConfig('DB_USER'),
+		host: config.host,
+		database: config.database,
+		password: config.password,
+		port: config.port,
+		user: config.user,
 	});
 	const db = drizzle(sql);
 

--- a/packages/data-provider/index.ts
+++ b/packages/data-provider/index.ts
@@ -2,6 +2,7 @@
 export { type AppConfig } from './src/config/config.js';
 export { default as provider } from './src/core/provider.js';
 export { errorHandler } from './src/middleware/errorHandler.js';
+export { migrate } from '@overture-stack/lyric-data-model';
 
 // routes
 export { default as dictionaryRouters } from './src/routers/dictionaryRouter.js';

--- a/packages/data-provider/src/config/config.ts
+++ b/packages/data-provider/src/config/config.ts
@@ -1,19 +1,12 @@
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 
-import * as schema from '@overture-stack/lyric-data-model';
+import type { DbConfig } from '@overture-stack/lyric-data-model';
+import * as schema from '@overture-stack/lyric-data-model/models';
 
 import { Logger } from './logger.js';
 
 export type AuditConfig = {
 	enabled: boolean;
-};
-
-export type DbConfig = {
-	host: string;
-	port: number;
-	database: string;
-	user: string;
-	password: string;
 };
 
 export type RecordHierarchyConfig = {

--- a/packages/data-provider/src/config/db.ts
+++ b/packages/data-provider/src/config/db.ts
@@ -1,11 +1,9 @@
 import { drizzle, NodePgDatabase } from 'drizzle-orm/node-postgres';
 import pg from 'pg';
 
-import * as schema from '@overture-stack/lyric-data-model';
+import { DbConfig, models } from '@overture-stack/lyric-data-model';
 
-import { DbConfig } from './config.js';
-
-export const connect = (config: DbConfig): NodePgDatabase<typeof schema> => {
+export const connect = (config: DbConfig): NodePgDatabase<typeof models> => {
 	const pool = new pg.Pool({
 		host: config.host,
 		port: config.port,
@@ -15,5 +13,5 @@ export const connect = (config: DbConfig): NodePgDatabase<typeof schema> => {
 	});
 	console.log(`Connecting to database on ${config.host}`);
 
-	return drizzle(pool, { schema });
+	return drizzle(pool, { schema: models });
 };

--- a/packages/data-provider/src/repository/activeSubmissionRepository.ts
+++ b/packages/data-provider/src/repository/activeSubmissionRepository.ts
@@ -1,6 +1,6 @@
 import { and, eq, or } from 'drizzle-orm/sql';
 
-import { NewSubmission, Submission, submissions } from '@overture-stack/lyric-data-model';
+import { NewSubmission, Submission, submissions } from '@overture-stack/lyric-data-model/models';
 
 import { BaseDependencies } from '../config/config.js';
 import { ServiceUnavailable } from '../utils/errors.js';

--- a/packages/data-provider/src/repository/auditRepository.ts
+++ b/packages/data-provider/src/repository/auditRepository.ts
@@ -1,6 +1,6 @@
 import { and, count, eq, gt, lt, SQL } from 'drizzle-orm';
 
-import { auditSubmittedData } from '@overture-stack/lyric-data-model';
+import { auditSubmittedData } from '@overture-stack/lyric-data-model/models';
 
 import { BaseDependencies } from '../config/config.js';
 import { convertToAuditEvent } from '../utils/auditUtils.js';

--- a/packages/data-provider/src/repository/categoryRepository.ts
+++ b/packages/data-provider/src/repository/categoryRepository.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm/sql';
 import { ListAllCategoriesResponse } from 'src/utils/types.js';
 
 import { Dictionary as SchemasDictionary } from '@overture-stack/lectern-client';
-import { Category, Dictionary, dictionaryCategories, NewCategory } from '@overture-stack/lyric-data-model';
+import { Category, Dictionary, dictionaryCategories, NewCategory } from '@overture-stack/lyric-data-model/models';
 
 import { BaseDependencies } from '../config/config.js';
 import { ServiceUnavailable } from '../utils/errors.js';

--- a/packages/data-provider/src/repository/dictionaryRepository.ts
+++ b/packages/data-provider/src/repository/dictionaryRepository.ts
@@ -1,6 +1,6 @@
 import { and, eq } from 'drizzle-orm/sql';
 
-import { dictionaries, Dictionary, NewDictionary } from '@overture-stack/lyric-data-model';
+import { dictionaries, Dictionary, NewDictionary } from '@overture-stack/lyric-data-model/models';
 
 import { BaseDependencies } from '../config/config.js';
 import { ServiceUnavailable } from '../utils/errors.js';

--- a/packages/data-provider/src/repository/submittedRepository.ts
+++ b/packages/data-provider/src/repository/submittedRepository.ts
@@ -8,7 +8,7 @@ import {
 	NewSubmittedData,
 	SubmittedData,
 	submittedData,
-} from '@overture-stack/lyric-data-model';
+} from '@overture-stack/lyric-data-model/models';
 
 import { BaseDependencies } from '../config/config.js';
 import { ServiceUnavailable } from '../utils/errors.js';

--- a/packages/data-provider/src/services/dictionaryService.ts
+++ b/packages/data-provider/src/services/dictionaryService.ts
@@ -1,7 +1,7 @@
 import { isEmpty } from 'lodash-es';
 
 import { Dictionary as SchemasDictionary, Schema } from '@overture-stack/lectern-client';
-import { Category, Dictionary, NewCategory, NewDictionary } from '@overture-stack/lyric-data-model';
+import { Category, Dictionary, NewCategory, NewDictionary } from '@overture-stack/lyric-data-model/models';
 
 import { BaseDependencies } from '../config/config.js';
 import lecternClient from '../external/lecternClient.js';

--- a/packages/data-provider/src/services/submission/processor.ts
+++ b/packages/data-provider/src/services/submission/processor.ts
@@ -12,7 +12,7 @@ import {
 	type SubmissionInsertData,
 	type SubmissionUpdateData,
 	SubmittedData,
-} from '@overture-stack/lyric-data-model';
+} from '@overture-stack/lyric-data-model/models';
 
 import { BaseDependencies } from '../../config/config.js';
 import submissionRepository from '../../repository/activeSubmissionRepository.js';

--- a/packages/data-provider/src/services/submission/submission.ts
+++ b/packages/data-provider/src/services/submission/submission.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash-es';
 
 import { Dictionary as SchemasDictionary } from '@overture-stack/lectern-client';
-import { type NewSubmission, Submission, type SubmissionUpdateData } from '@overture-stack/lyric-data-model';
+import { type NewSubmission, Submission, type SubmissionUpdateData } from '@overture-stack/lyric-data-model/models';
 
 import { BaseDependencies } from '../../config/config.js';
 import systemIdGenerator from '../../external/systemIdGenerator.js';

--- a/packages/data-provider/src/services/submittedData/searchDataRelations.ts
+++ b/packages/data-provider/src/services/submittedData/searchDataRelations.ts
@@ -1,5 +1,5 @@
 import type { DataRecord } from '@overture-stack/lectern-client';
-import type { SubmittedData } from '@overture-stack/lyric-data-model';
+import type { SubmittedData } from '@overture-stack/lyric-data-model/models';
 
 import type { BaseDependencies } from '../../config/config.js';
 import submittedRepository from '../../repository/submittedRepository.js';

--- a/packages/data-provider/src/utils/submissionUtils.ts
+++ b/packages/data-provider/src/utils/submissionUtils.ts
@@ -16,7 +16,7 @@ import {
 	type SubmissionInsertData,
 	type SubmissionUpdateData,
 	type SubmittedData,
-} from '@overture-stack/lyric-data-model';
+} from '@overture-stack/lyric-data-model/models';
 
 import type { SchemaChildNode } from './dictionarySchemaRelations.js';
 import { getSchemaFieldNames } from './dictionaryUtils.js';

--- a/packages/data-provider/src/utils/submittedDataUtils.ts
+++ b/packages/data-provider/src/utils/submittedDataUtils.ts
@@ -11,7 +11,7 @@ import {
 	type SubmissionDeleteData,
 	type SubmissionUpdateData,
 	SubmittedData,
-} from '@overture-stack/lyric-data-model';
+} from '@overture-stack/lyric-data-model/models';
 
 import {
 	DataRecordReference,

--- a/packages/data-provider/src/utils/types.ts
+++ b/packages/data-provider/src/utils/types.ts
@@ -17,7 +17,7 @@ import {
 	type SubmissionDeleteData,
 	type SubmissionUpdateData,
 	type SubmittedData,
-} from '@overture-stack/lyric-data-model';
+} from '@overture-stack/lyric-data-model/models';
 
 type ObjectValues<T> = T[keyof T];
 

--- a/packages/data-provider/test/utils/fixtures/dictionarySchemasTestData.ts
+++ b/packages/data-provider/test/utils/fixtures/dictionarySchemasTestData.ts
@@ -1,5 +1,5 @@
 import { Schema } from '@overture-stack/lectern-client';
-import { Dictionary } from '@overture-stack/lyric-data-model';
+import { Dictionary } from '@overture-stack/lyric-data-model/models';
 
 export const dictionarySportsData: Schema[] = [
 	{

--- a/packages/data-provider/test/utils/submissionUtils.spec.ts
+++ b/packages/data-provider/test/utils/submissionUtils.spec.ts
@@ -14,7 +14,7 @@ import type {
 	SubmissionInsertData,
 	SubmissionUpdateData,
 	SubmittedData,
-} from '@overture-stack/lyric-data-model';
+} from '@overture-stack/lyric-data-model/models';
 
 import type { SchemaChildNode } from '../../src/utils/dictionarySchemaRelations.js';
 import {

--- a/packages/data-provider/test/utils/submittedDataUtils.spec.ts
+++ b/packages/data-provider/test/utils/submittedDataUtils.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { type DictionaryValidationRecordErrorDetails, type SchemaRecordError } from '@overture-stack/lectern-client';
-import type { NewSubmittedData, SubmittedData } from '@overture-stack/lyric-data-model';
+import type { NewSubmittedData, SubmittedData } from '@overture-stack/lyric-data-model/models';
 
 import {
 	computeDataDiff,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@overture-stack/lectern-client':
         specifier: 2.0.0-beta.3
         version: 2.0.0-beta.3
+      copyfiles:
+        specifier: ^2.4.1
+        version: 2.4.1
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -1446,7 +1449,6 @@ packages:
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
@@ -1458,7 +1460,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -1691,7 +1692,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-    dev: true
 
   /cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1713,7 +1713,6 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -1809,7 +1808,6 @@ packages:
       through2: 2.0.5
       untildify: 4.0.0
       yargs: 16.2.0
-    dev: true
 
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -2110,7 +2108,6 @@ packages:
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-    dev: true
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
@@ -2284,7 +2281,6 @@ packages:
   /escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
     engines: {node: '>=6'}
-    dev: true
 
   /escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -2629,7 +2625,6 @@ packages:
   /get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-    dev: true
 
   /get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
@@ -2700,7 +2695,6 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-    dev: true
 
   /glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -2886,7 +2880,6 @@ packages:
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-    dev: true
 
   /is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -2931,7 +2924,6 @@ packages:
 
   /isarray@0.0.1:
     resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
-    dev: true
 
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -3212,7 +3204,6 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: true
 
   /mocha@10.6.0:
     resolution: {integrity: sha512-hxjt4+EEB0SA0ZDygSS015t65lJw/I2yRCS3Ae+SJ5FrbzrXgfYwJr96f0OvIXdj7h4lv/vLCrH3rkiuizFSvw==}
@@ -3328,7 +3319,6 @@ packages:
     dependencies:
       inherits: 2.0.4
       readable-stream: 1.0.34
-    dev: true
 
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -3654,7 +3644,6 @@ packages:
       inherits: 2.0.4
       isarray: 0.0.1
       string_decoder: 0.10.31
-    dev: true
 
   /readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -3686,7 +3675,6 @@ packages:
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3897,7 +3885,6 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-    dev: true
 
   /string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
@@ -3910,7 +3897,6 @@ packages:
 
   /string_decoder@0.10.31:
     resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
-    dev: true
 
   /string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -3928,7 +3914,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
-    dev: true
 
   /strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
@@ -4038,7 +4023,6 @@ packages:
     dependencies:
       readable-stream: 2.3.8
       xtend: 4.0.2
-    dev: true
 
   /timers-ext@0.1.8:
     resolution: {integrity: sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==}
@@ -4166,7 +4150,6 @@ packages:
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
     engines: {node: '>=8'}
-    dev: true
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -4266,7 +4249,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
@@ -4287,7 +4269,6 @@ packages:
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
-    dev: true
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -4301,7 +4282,6 @@ packages:
   /yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
-    dev: true
 
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -4329,7 +4309,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
-    dev: true
 
   /yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}


### PR DESCRIPTION
## Description
Provide a function to run database migration.

## Package `Data Model` changes:
- The `migrate` function, located in `src/functions/migrate.ts`, is exported to enable running migrations from external applications.
- The script `scripts/migrate.js` is provided to execute migrations within the monorepo.
- The type `DbConfig` is being exported to define the database parameters.
