### PR TITLE
Add customizable callback for post-commit

### DIFF
--- a/packages/data-provider/README.md
+++ b/packages/data-provider/README.md
@@ -8,7 +8,9 @@
 npm i @overture-stack/lyric
 ```
 
-## Usage
+## Configuration
+
+### Provider
 
 Import `AppConfig` and `provider` from `@overture-stack/lyric` module to initialize the provider with custom configuration:
 
@@ -42,6 +44,43 @@ const appConfig: AppConfig = {
 
 const lyricProvider = provider(appConfig);
 ```
+
+### On Finish Commit Callback function
+
+The `onFinishCommit` callback function is executed automatically when a commit event is completed. This function provides the ability to customize the behavior or perform any additional actions after the commit is finished, using the result of the commit operation.
+
+Example:
+
+```javascript
+const onFinishCommitCallback: (resultOnCommit: ResultOnCommit) => {
+    // Check if there are inserts, updates, or deletes
+    if (resultOnCommit.data) {
+      const { inserts, updates, deletes } = resultOnCommit.data;
+
+      // Log the results to the console
+      console.log(`Inserts: ${inserts.length}`);
+      console.log(`Updates: ${updates.length}`);
+      console.log(`Deletes: ${deletes.length}`);
+    }
+
+    // You can also perform additional custom actions here
+    // For example index the data, or make another API call
+  }
+```
+
+To use the `onFinishCommit` callback, it requires to be defined in the AppConfig object:
+
+```javascript
+
+const appConfig: AppConfig = {
+	...// Other configuration
+	onFinishCommit: onFinishCommitCallback;
+}
+```
+
+## Usage
+
+### Express Routers
 
 Use any of the resources available on provider on a Express server:
 

--- a/packages/data-provider/src/config/config.ts
+++ b/packages/data-provider/src/config/config.ts
@@ -3,6 +3,7 @@ import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import type { DbConfig } from '@overture-stack/lyric-data-model';
 import * as schema from '@overture-stack/lyric-data-model/models';
 
+import type { ResultOnCommit } from '../utils/types.js';
 import { Logger } from './logger.js';
 
 export type AuditConfig = {
@@ -48,6 +49,7 @@ export type AppConfig = {
 	limits: LimitsConfig;
 	logger: LoggerConfig;
 	schemaService: SchemaServiceConfig;
+	onFinishCommit?: (resultOnCommit: ResultOnCommit) => void;
 };
 
 /**
@@ -60,4 +62,5 @@ export interface BaseDependencies {
 	limits: LimitsConfig;
 	logger: Logger;
 	schemaService: SchemaServiceConfig;
+	onFinishCommit?: (resultOnCommit: ResultOnCommit) => void;
 }

--- a/packages/data-provider/src/core/provider.ts
+++ b/packages/data-provider/src/core/provider.ts
@@ -40,6 +40,7 @@ const provider = (configData: AppConfig) => {
 		limits: configData.limits,
 		logger: getLogger(configData.logger),
 		schemaService: configData.schemaService,
+		onFinishCommit: configData.onFinishCommit,
 	};
 
 	return {

--- a/packages/data-provider/src/repository/activeSubmissionRepository.ts
+++ b/packages/data-provider/src/repository/activeSubmissionRepository.ts
@@ -1,3 +1,6 @@
+import type { ExtractTablesWithRelations } from 'drizzle-orm';
+import type { PgTransaction } from 'drizzle-orm/pg-core';
+import type { PostgresJsQueryResultHKT } from 'drizzle-orm/postgres-js';
 import { and, count, eq, or } from 'drizzle-orm/sql';
 
 import { NewSubmission, Submission, submissions } from '@overture-stack/lyric-data-model/models';
@@ -117,11 +120,16 @@ const repository = (dependencies: BaseDependencies) => {
 		 * Update a Submission record in database
 		 * @param {number} submissionId Submission ID to update
 		 * @param {Partial<Submission>} newData Set fields to update
+		 * @param tx The transaction to use for the operation, optional
 		 * @returns An updated record
 		 */
-		update: async (submissionId: number, newData: Partial<Submission>): Promise<Submission> => {
+		update: async (
+			submissionId: number,
+			newData: Partial<Submission>,
+			tx?: PgTransaction<PostgresJsQueryResultHKT, Submission, ExtractTablesWithRelations<Submission>>,
+		): Promise<Submission> => {
 			try {
-				const resultUpdate = await db
+				const resultUpdate = await (tx || db)
 					.update(submissions)
 					.set({ ...newData, updatedAt: new Date() })
 					.where(eq(submissions.id, submissionId))

--- a/packages/data-provider/src/repository/submittedRepository.ts
+++ b/packages/data-provider/src/repository/submittedRepository.ts
@@ -1,3 +1,6 @@
+import type { ExtractTablesWithRelations } from 'drizzle-orm';
+import type { PgTransaction } from 'drizzle-orm/pg-core';
+import type { PostgresJsQueryResultHKT } from 'drizzle-orm/postgres-js';
 import { and, count, eq, or, SQL, sql } from 'drizzle-orm/sql';
 import * as _ from 'lodash-es';
 
@@ -18,12 +21,15 @@ const repository = (dependencies: BaseDependencies) => {
 	const LOG_MODULE = 'SUBMITTEDDATA_REPOSITORY';
 	const { db, logger, features } = dependencies;
 
-	const auditDeleteSubmittedData = async (input: {
-		recordDeleted: SubmittedData;
-		diff: DataDiff;
-		submissionId: number;
-		userName: string;
-	}) => {
+	const auditDeleteSubmittedData = async (
+		input: {
+			recordDeleted: SubmittedData;
+			diff: DataDiff;
+			submissionId: number;
+			userName: string;
+		},
+		tx?: PgTransaction<PostgresJsQueryResultHKT, SubmittedData, ExtractTablesWithRelations<SubmittedData>>,
+	) => {
 		const { recordDeleted, diff, submissionId, userName } = input;
 		const newAudit: NewAuditSubmittedData = {
 			action: AUDIT_ACTION.Values.DELETE,
@@ -40,20 +46,23 @@ const repository = (dependencies: BaseDependencies) => {
 			createdAt: new Date(),
 			createdBy: userName,
 		};
-		return await db.insert(auditSubmittedData).values(newAudit);
+		return await (tx || db).insert(auditSubmittedData).values(newAudit);
 	};
 
-	const auditUpdateSubmittedData = async ({
-		dataDiff,
-		oldIsValid,
-		recordUpdated,
-		submissionId,
-	}: {
-		dataDiff: DataDiff;
-		oldIsValid: boolean;
-		recordUpdated: SubmittedData;
-		submissionId: number;
-	}) => {
+	const auditUpdateSubmittedData = async (
+		{
+			dataDiff,
+			oldIsValid,
+			recordUpdated,
+			submissionId,
+		}: {
+			dataDiff: DataDiff;
+			oldIsValid: boolean;
+			recordUpdated: SubmittedData;
+			submissionId: number;
+		},
+		tx?: PgTransaction<PostgresJsQueryResultHKT, SubmittedData, ExtractTablesWithRelations<SubmittedData>>,
+	) => {
 		const newAudit: NewAuditSubmittedData = {
 			action: AUDIT_ACTION.Values.UPDATE,
 			dictionaryCategoryId: recordUpdated.dictionaryCategoryId,
@@ -69,7 +78,7 @@ const repository = (dependencies: BaseDependencies) => {
 			createdAt: new Date(),
 			createdBy: recordUpdated.updatedBy,
 		};
-		return await db.insert(auditSubmittedData).values(newAudit);
+		return await (tx || db).insert(auditSubmittedData).values(newAudit);
 	};
 
 	// Column name on the database used to build JSONB query
@@ -107,15 +116,22 @@ const repository = (dependencies: BaseDependencies) => {
 		 * @param params.submissionId The ID of the Submission associated with the record
 		 * @param params.systemId The unique identifier of the record to delete
 		 * @param params.userName The name of the user performing the deletion
+		 * @param tx The transaction to use for the operation, optional
 		 * @returns The deleted record
 		 */
-		deleteBySystemId: async (params: { diff: DataDiff; submissionId: number; systemId: string; userName: string }) => {
+		deleteBySystemId: async (
+			params: { diff: DataDiff; submissionId: number; systemId: string; userName: string },
+			tx?: PgTransaction<PostgresJsQueryResultHKT, SubmittedData, ExtractTablesWithRelations<SubmittedData>>,
+		) => {
 			const { diff, systemId, submissionId, userName } = params;
-			const deletedRecord = await db.delete(submittedData).where(eq(submittedData.systemId, systemId)).returning();
+			const deletedRecord = await (tx || db)
+				.delete(submittedData)
+				.where(eq(submittedData.systemId, systemId))
+				.returning();
 			logger.info(LOG_MODULE, `Deleting SubmittedData with system ID '${systemId}' succesfully`);
 
 			if (features?.audit?.enabled) {
-				await auditDeleteSubmittedData({ recordDeleted: deletedRecord[0], submissionId, diff, userName });
+				await auditDeleteSubmittedData({ recordDeleted: deletedRecord[0], submissionId, diff, userName }, tx);
 			}
 
 			return deletedRecord;
@@ -124,11 +140,15 @@ const repository = (dependencies: BaseDependencies) => {
 		/**
 		 * Save new SubmittedData in Database
 		 * @param data A SubmittedData object to be saved
+		 * @param tx The transaction to use for the operation, optional
 		 * @returns The created SubmittedData
 		 */
-		save: async (data: NewSubmittedData): Promise<SubmittedData> => {
+		save: async (
+			data: NewSubmittedData,
+			tx?: PgTransaction<PostgresJsQueryResultHKT, SubmittedData, ExtractTablesWithRelations<SubmittedData>>,
+		): Promise<SubmittedData> => {
 			try {
-				const savedSubmittedData = await db.insert(submittedData).values(data).returning();
+				const savedSubmittedData = await (tx || db).insert(submittedData).values(data).returning();
 				logger.debug(
 					LOG_MODULE,
 					`Submitting Data with entity name '${data.entityName}' on category '${data.dictionaryCategoryId}' saved successfully`,
@@ -329,30 +349,34 @@ const repository = (dependencies: BaseDependencies) => {
 		 * @param newData Set fields to update
 		 * @param oldIsValid Previous isValid value
 		 * @param submissionId Submission ID
+		 * @param tx The transaction to use for the operation, optional
 		 * @returns An updated record
 		 */
-		update: async ({
-			submittedDataId,
-			dataDiff,
-			newData,
-			oldIsValid,
-			submissionId,
-		}: {
-			submittedDataId: number;
-			dataDiff: DataDiff;
-			newData: Partial<SubmittedData>;
-			oldIsValid: boolean;
-			submissionId: number;
-		}): Promise<SubmittedData> => {
+		update: async (
+			{
+				submittedDataId,
+				dataDiff,
+				newData,
+				oldIsValid,
+				submissionId,
+			}: {
+				submittedDataId: number;
+				dataDiff: DataDiff;
+				newData: Partial<SubmittedData>;
+				oldIsValid: boolean;
+				submissionId: number;
+			},
+			tx?: PgTransaction<PostgresJsQueryResultHKT, SubmittedData, ExtractTablesWithRelations<SubmittedData>>,
+		): Promise<SubmittedData> => {
 			try {
-				const updated = await db
+				const updated = await (tx || db)
 					.update(submittedData)
 					.set({ ...newData, updatedAt: new Date() })
 					.where(eq(submittedData.id, submittedDataId))
 					.returning();
 
 				if (features?.audit?.enabled && !_.isEmpty(dataDiff.new) && !_.isEmpty(dataDiff.old)) {
-					await auditUpdateSubmittedData({ recordUpdated: updated[0], submissionId, dataDiff, oldIsValid });
+					await auditUpdateSubmittedData({ recordUpdated: updated[0], submissionId, dataDiff, oldIsValid }, tx);
 				}
 				return updated[0];
 			} catch (error) {

--- a/packages/data-provider/src/services/submission/submission.ts
+++ b/packages/data-provider/src/services/submission/submission.ts
@@ -31,7 +31,7 @@ import processor from './processor.js';
 
 const service = (dependencies: BaseDependencies) => {
 	const LOG_MODULE = 'SUBMISSION_SERVICE';
-	const { logger } = dependencies;
+	const { logger, onFinishCommit } = dependencies;
 	const { performCommitSubmissionAsync, performDataValidation } = processor(dependencies);
 
 	/**
@@ -125,6 +125,7 @@ const service = (dependencies: BaseDependencies) => {
 			submission,
 			dictionary: currentDictionary,
 			userName: userName,
+			onFinishCommit,
 		});
 
 		return {

--- a/packages/data-provider/src/utils/types.ts
+++ b/packages/data-provider/src/utils/types.ts
@@ -305,9 +305,11 @@ export type SubmittedDataResponse = {
  */
 export type ResultOnCommit = {
 	submissionId: number;
+	organization: string;
+	categoryId: number;
 	data?: {
 		inserts: SubmittedDataResponse[];
-		udpates: SubmittedDataResponse[];
+		updates: SubmittedDataResponse[];
 		deletes: SubmittedDataResponse[];
 	};
 };

--- a/packages/data-provider/src/utils/types.ts
+++ b/packages/data-provider/src/utils/types.ts
@@ -177,6 +177,7 @@ export interface CommitSubmissionParams {
 	dictionary: SchemasDictionary & { id: number };
 	submission: Submission;
 	userName: string;
+	onFinishCommit?: (resultOnCommit: ResultOnCommit) => void;
 }
 
 export type GroupedDataSubmission = {
@@ -297,6 +298,18 @@ export type SubmittedDataResponse = {
 	isValid: boolean;
 	organization: string;
 	systemId: string;
+};
+
+/**
+ * Result type Post-Commit Submission
+ */
+export type ResultOnCommit = {
+	submissionId: number;
+	data?: {
+		inserts: SubmittedDataResponse[];
+		udpates: SubmittedDataResponse[];
+		deletes: SubmittedDataResponse[];
+	};
 };
 
 /**


### PR DESCRIPTION
## Features
- Customizable callback function to run once immediately after a **commit** data request has been executed. Added README doc section how to use it.
- Use database transaction provided by Drizzle `PgTransaction`