### PR TITLE
Fix issue comparing Submitted Data property names

### DIFF
--- a/packages/data-provider/src/utils/submittedDataUtils.ts
+++ b/packages/data-provider/src/utils/submittedDataUtils.ts
@@ -244,13 +244,27 @@ export const mapAndMergeSubmittedDataToRecordReferences = ({
 		let record: DataRecordReference;
 		if (editSubmittedData && foundRecordToUpdateIndex >= 0) {
 			const recordToUpdate = editSubmittedData[entityData.entityName][foundRecordToUpdateIndex];
-			const newDataToUpdate: MutableDataRecord = entityData.data;
-			for (const key of Object.keys(recordToUpdate.old)) {
-				if (entityData.data[key] !== recordToUpdate.old[key]) {
-					// What to do if record on Submission doesn't match with current SubmittedData?
+			const existingData: DataRecord = entityData.data;
+
+			// Remove old keys
+			const keysToRemove = Object.keys(recordToUpdate.old);
+			const newDataToUpdate = Object.keys(existingData).reduce<MutableDataRecord>((acc, key) => {
+				if (!keysToRemove.includes(key)) {
+					acc[key] = existingData[key];
 				}
-				newDataToUpdate[key] = recordToUpdate.new[key];
+				return acc;
+			}, {});
+
+			// Filter undefined values from new object
+			const filteredNewObject: DataRecord = {};
+			for (const key in recordToUpdate.new) {
+				if (recordToUpdate.new[key] !== undefined) {
+					filteredNewObject[key] = recordToUpdate.new[key];
+				}
 			}
+
+			Object.assign(newDataToUpdate, filteredNewObject);
+
 			record = {
 				dataRecord: newDataToUpdate,
 				reference: {


### PR DESCRIPTION
# Pull Request

## Description
This PR solves an issue where updating Submitted data through the PUT endpoint creates an INVALID submission. 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] Tested on local environment. Create a .csv with 10 records to be updated. Upload a .csv to `PUT /submission/category/{categoryId/data`. Verify the submission created is VALID and contains the new changes.

## Checklist:

You do not need to fullfill all requirements of this checklist, select all that apply:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
