### PR TITLE
Allow defaultCentricEntity to be set as empty without returning an error

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -47,6 +47,7 @@ app.use('/data', lyricProvider.routers.submittedData);
 app.use('/dictionary', lyricProvider.routers.dictionary);
 app.use('/submission', lyricProvider.routers.submission);
 app.use('/validator', lyricProvider.routers.validator);
+app.use('/organization', lyricProvider.routers.organization);
 
 // Swagger route
 app.use('/api-docs', serve, setup(swaggerDoc));

--- a/apps/server/swagger/organization-api.yml
+++ b/apps/server/swagger/organization-api.yml
@@ -1,0 +1,132 @@
+# Description of Organization API
+
+/organization:
+  post:
+    summary: Register a new organization
+    tags:
+      - Organization
+    requestBody:
+      description: Organization registration payload
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - name
+            properties:
+              name:
+                type: string
+                description: The name of the organization to register
+    responses:
+      200:
+        description: Organization registered successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Organization'
+      400:
+        $ref: '#/components/responses/BadRequest'
+      401:
+        $ref: '#/components/responses/UnauthorizedError'
+      409:
+        description: Conflict - organization already exists
+      500:
+        $ref: '#/components/responses/ServerError'
+      503:
+        $ref: '#/components/responses/ServiceUnavailableError'
+
+/organization/{id}:
+  delete:
+    summary: Delete an organization by ID
+    tags:
+      - Organization
+    parameters:
+      - name: id
+        in: path
+        description: The ID of the organization to delete
+        required: true
+        schema:
+          type: integer
+    responses:
+      200:
+        description: Organization deleted successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                success:
+                  type: boolean
+                id:
+                  type: integer
+      400:
+        $ref: '#/components/responses/BadRequest'
+      401:
+        $ref: '#/components/responses/UnauthorizedError'
+      404:
+        $ref: '#/components/responses/NotFound'
+      500:
+        $ref: '#/components/responses/ServerError'
+      503:
+        $ref: '#/components/responses/ServiceUnavailableError'
+
+components:
+  schemas:
+    Organization:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+    UnauthorizedError:
+      description: Unauthorized access
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+    ServerError:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+    ServiceUnavailableError:
+      description: Service unavailable
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string

--- a/packages/data-model/docs/schema.dbml
+++ b/packages/data-model/docs/schema.dbml
@@ -48,6 +48,12 @@ table dictionary_categories {
   updated_by varchar
 }
 
+table organizations {
+  id serial [pk, not null, increment]
+  name varchar [not null, unique]
+  created_at timestamp [not null, default: `now()`]
+}
+
 table submissions {
   id serial [pk, not null, increment]
   data jsonb [not null]

--- a/packages/data-model/migrations/0010_melodic_agent_brand.sql
+++ b/packages/data-model/migrations/0010_melodic_agent_brand.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS "organizations" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "organizations_name_unique" UNIQUE("name")
+);

--- a/packages/data-model/migrations/meta/0010_snapshot.json
+++ b/packages/data-model/migrations/meta/0010_snapshot.json
@@ -1,0 +1,582 @@
+{
+  "id": "29661913-7dcb-4c55-bee5-090bd9710613",
+  "prevId": "9d7d98fa-e067-4891-a2c1-65a19d6430f3",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "audit_submitted_data": {
+      "name": "audit_submitted_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "audit_action",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dictionary_category_id": {
+          "name": "dictionary_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_diff": {
+          "name": "data_diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_valid_schema_id": {
+          "name": "last_valid_schema_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_data_is_valid": {
+          "name": "new_data_is_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_data_is_valid": {
+          "name": "old_data_is_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization": {
+          "name": "organization",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_schema_id": {
+          "name": "original_schema_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_submitted_data_dictionary_category_id_dictionary_categories_id_fk": {
+          "name": "audit_submitted_data_dictionary_category_id_dictionary_categories_id_fk",
+          "tableFrom": "audit_submitted_data",
+          "tableTo": "dictionary_categories",
+          "columnsFrom": [
+            "dictionary_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_submitted_data_last_valid_schema_id_dictionaries_id_fk": {
+          "name": "audit_submitted_data_last_valid_schema_id_dictionaries_id_fk",
+          "tableFrom": "audit_submitted_data",
+          "tableTo": "dictionaries",
+          "columnsFrom": [
+            "last_valid_schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_submitted_data_original_schema_id_dictionaries_id_fk": {
+          "name": "audit_submitted_data_original_schema_id_dictionaries_id_fk",
+          "tableFrom": "audit_submitted_data",
+          "tableTo": "dictionaries",
+          "columnsFrom": [
+            "original_schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_submitted_data_submission_id_submissions_id_fk": {
+          "name": "audit_submitted_data_submission_id_submissions_id_fk",
+          "tableFrom": "audit_submitted_data",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "dictionaries": {
+      "name": "dictionaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dictionary": {
+          "name": "dictionary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "dictionary_categories": {
+      "name": "dictionary_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active_dictionary_id": {
+          "name": "active_dictionary_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_centric_entity": {
+          "name": "default_centric_entity",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dictionary_categories_name_unique": {
+          "name": "dictionary_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dictionary_category_id": {
+          "name": "dictionary_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dictionary_id": {
+          "name": "dictionary_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization": {
+          "name": "organization",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "submission_status",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submissions_dictionary_category_id_dictionary_categories_id_fk": {
+          "name": "submissions_dictionary_category_id_dictionary_categories_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "dictionary_categories",
+          "columnsFrom": [
+            "dictionary_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_dictionary_id_dictionaries_id_fk": {
+          "name": "submissions_dictionary_id_dictionaries_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "dictionaries",
+          "columnsFrom": [
+            "dictionary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "submitted_data": {
+      "name": "submitted_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dictionary_category_id": {
+          "name": "dictionary_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_valid_schema_id": {
+          "name": "last_valid_schema_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization": {
+          "name": "organization",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_schema_id": {
+          "name": "original_schema_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_index": {
+          "name": "organization_index",
+          "columns": [
+            "organization"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "submitted_data_dictionary_category_id_dictionary_categories_id_fk": {
+          "name": "submitted_data_dictionary_category_id_dictionary_categories_id_fk",
+          "tableFrom": "submitted_data",
+          "tableTo": "dictionary_categories",
+          "columnsFrom": [
+            "dictionary_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submitted_data_last_valid_schema_id_dictionaries_id_fk": {
+          "name": "submitted_data_last_valid_schema_id_dictionaries_id_fk",
+          "tableFrom": "submitted_data",
+          "tableTo": "dictionaries",
+          "columnsFrom": [
+            "last_valid_schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submitted_data_original_schema_id_dictionaries_id_fk": {
+          "name": "submitted_data_original_schema_id_dictionaries_id_fk",
+          "tableFrom": "submitted_data",
+          "tableTo": "dictionaries",
+          "columnsFrom": [
+            "original_schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submitted_data_system_id_unique": {
+          "name": "submitted_data_system_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "system_id"
+          ]
+        }
+      }
+    },
+    "organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_name_unique": {
+          "name": "organizations_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "audit_action": {
+      "name": "audit_action",
+      "values": {
+        "UPDATE": "UPDATE",
+        "DELETE": "DELETE"
+      }
+    },
+    "submission_status": {
+      "name": "submission_status",
+      "values": {
+        "OPEN": "OPEN",
+        "VALID": "VALID",
+        "INVALID": "INVALID",
+        "CLOSED": "CLOSED",
+        "COMMITTED": "COMMITTED"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/data-model/migrations/meta/_journal.json
+++ b/packages/data-model/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1730128901514,
       "tag": "0009_add_default_centric_entity",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "5",
+      "when": 1755884401529,
+      "tag": "0010_melodic_agent_brand",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/data-model/src/models/index.ts
+++ b/packages/data-model/src/models/index.ts
@@ -3,3 +3,4 @@ export * from './dictionaries.js';
 export * from './dictionary_categories.js';
 export * from './submissions.js';
 export * from './submitted_data.js';
+export * from './organization.js';

--- a/packages/data-model/src/models/organization.ts
+++ b/packages/data-model/src/models/organization.ts
@@ -1,0 +1,10 @@
+import { pgTable, serial, varchar, timestamp } from 'drizzle-orm/pg-core';
+
+export const organizations = pgTable('organizations', {
+	id: serial('id').primaryKey(),
+	name: varchar('name').notNull().unique(),
+	createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export type Organization = typeof organizations.$inferSelect;
+export type NewOrganization = typeof organizations.$inferInsert;

--- a/packages/data-provider/index.ts
+++ b/packages/data-provider/index.ts
@@ -9,6 +9,7 @@ export { type DbConfig, migrate } from '@overture-stack/lyric-data-model';
 export { default as dictionaryRouters } from './src/routers/dictionaryRouter.js';
 export { default as submissionRouter } from './src/routers/submissionRouter.js';
 export { default as submittedDataRouter } from './src/routers/submittedDataRouter.js';
+export { default as organizationRouter } from './src/routers/organizationRouter.js';
 
 // utils
 export * from './src/utils/dictionaryUtils.js';

--- a/packages/data-provider/src/controllers/organizationController.ts
+++ b/packages/data-provider/src/controllers/organizationController.ts
@@ -1,0 +1,64 @@
+import type { NextFunction, Request, Response } from 'express';
+
+import { BaseDependencies } from '../config/config.js';
+import organizationSvc from '../services/organizationService.js';
+import { NotFound } from '../utils/errors.js';
+import { validateRequest } from '../utils/requestValidation.js';
+import { registerOrganizationSchema, deleteOrganizationSchema } from '../utils/schemas.js';
+import { Organization } from '@overture-stack/lyric-data-model/models';
+
+const controller = (dependencies: BaseDependencies) => {
+	const organizationService = organizationSvc(dependencies);
+	const { logger } = dependencies;
+	const LOG_MODULE = 'ORGANIZATION_CONTROLLER';
+
+	return {
+		/**
+		 * Registers a new organization if it does not exist
+		 */
+		registerOrganization: validateRequest(
+			registerOrganizationSchema,
+			async (req: Request, res: Response, next: NextFunction) => {
+				try {
+					const { name } = req.body;
+
+					logger.info(LOG_MODULE, `Register Organization request name='${name}'`);
+
+					const organization: Organization = await organizationService.registerOrganization(name);
+
+					return res.status(200).send(organization);
+				} catch (error) {
+					logger.error(LOG_MODULE, 'Error registering organization', error);
+					next(error);
+				}
+			},
+		),
+
+		/**
+		 * Deletes an organization by ID
+		 */
+		deleteOrganization: validateRequest(
+			deleteOrganizationSchema,
+			async (req: Request, res: Response, next: NextFunction) => {
+				try {
+					const orgId = Number(req.params.id);
+
+					logger.info(LOG_MODULE, `Delete Organization request id='${orgId}'`);
+
+					const deleted = await organizationService.deleteOrganization(orgId);
+
+					if (!deleted) {
+						throw new NotFound(`Organization with ID '${orgId}' not found`);
+					}
+
+					return res.status(200).send({ success: true, id: orgId });
+				} catch (error) {
+					logger.error(LOG_MODULE, 'Error deleting organization', error);
+					next(error);
+				}
+			},
+		),
+	};
+};
+
+export default controller;

--- a/packages/data-provider/src/core/provider.ts
+++ b/packages/data-provider/src/core/provider.ts
@@ -1,3 +1,4 @@
+import organizationRouter from '../routers/organizationRouter.js';
 import { AppConfig, BaseDependencies } from '../config/config.js';
 import { connect } from '../config/db.js';
 import { getLogger } from '../config/logger.js';
@@ -7,11 +8,13 @@ import dictionaryController from '../controllers/dictionaryController.js';
 import submissionController from '../controllers/submissionController.js';
 import submittedDataController from '../controllers/submittedDataController.js';
 import validationController from '../controllers/validationController.js';
+import organizationController from '../controllers/organizationController.js';
 import submissionRepository from '../repository/activeSubmissionRepository.js';
 import auditRepository from '../repository/auditRepository.js';
 import categoryRepository from '../repository/categoryRepository.js';
 import dictionaryRepository from '../repository/dictionaryRepository.js';
 import submittedDataRepository from '../repository/submittedRepository.js';
+import organizationRepository from '../repository/organizationRepository.js';
 import auditRouter from '../routers/auditRouter.js';
 import categoryRouter from '../routers/categoryRouter.js';
 import dictionaryRouter from '../routers/dictionaryRouter.js';
@@ -33,6 +36,8 @@ import * as schemaUtils from '../utils/schemas.js';
 import * as submissionUtils from '../utils/submissionUtils.js';
 import * as submittedDataUtils from '../utils/submittedDataUtils.js';
 import * as typeUtils from '../utils/types.js';
+import { organizations } from '@overture-stack/lyric-data-model/models';
+import organizationService from '../services/organizationService.js';
 
 /**
  * The main provider of submission resources
@@ -62,6 +67,7 @@ const provider = (configData: AppConfig) => {
 				authConfig: configData.auth,
 				validatorConfig: configData.validator,
 			}),
+			organization: organizationRouter({ baseDependencies: baseDeps, authConfig: configData.auth }),
 		},
 		controllers: {
 			audit: auditController(baseDeps),
@@ -73,6 +79,7 @@ const provider = (configData: AppConfig) => {
 			}),
 			submittedData: submittedDataController(baseDeps),
 			validator: validationController({ baseDependencies: baseDeps, validatorConfig: configData.validator }),
+			organizations: organizationController(baseDeps),
 		},
 		services: {
 			audit: auditService(baseDeps),
@@ -81,6 +88,7 @@ const provider = (configData: AppConfig) => {
 			submission: submissionService(baseDeps),
 			submittedData: submittedDataService(baseDeps),
 			validation: validationService(baseDeps),
+			organization: organizationService(baseDeps),
 		},
 		repositories: {
 			audit: auditRepository(baseDeps),
@@ -88,6 +96,7 @@ const provider = (configData: AppConfig) => {
 			dictionary: dictionaryRepository(baseDeps),
 			submission: submissionRepository(baseDeps),
 			submittedData: submittedDataRepository(baseDeps),
+			organization: organizationRepository(baseDeps),
 		},
 		utils: {
 			audit: auditUtils,

--- a/packages/data-provider/src/repository/organizationRepository.ts
+++ b/packages/data-provider/src/repository/organizationRepository.ts
@@ -1,0 +1,76 @@
+import { eq } from 'drizzle-orm/sql';
+
+import { organizations, Organization, NewOrganization } from '@overture-stack/lyric-data-model/models';
+import { BaseDependencies } from '../config/config.js';
+import { ServiceUnavailable } from '../utils/errors.js';
+
+const repository = (dependencies: BaseDependencies) => {
+	const LOG_MODULE = 'ORGANIZATION_REPOSITORY';
+	const { db, logger } = dependencies;
+
+	return {
+		/**
+		 * Save a new Organization in the database
+		 * @param data A new organization object to be saved
+		 * @returns The created Organization
+		 */
+		save: async (data: NewOrganization): Promise<Organization> => {
+			try {
+				const savedOrg = await db.insert(organizations).values(data).returning();
+				logger.info(LOG_MODULE, `Organization '${data.name}' saved successfully`);
+				return savedOrg[0];
+			} catch (error) {
+				logger.error(LOG_MODULE, `Failed to save Organization '${data.name}'`, error);
+				throw error;
+			}
+		},
+
+		/**
+		 * Finds an Organization by name
+		 * @param {string} name Organization name
+		 * @returns The Organization found or undefined
+		 */
+		getOrganizationByName: async (name: string): Promise<Organization | undefined> => {
+			try {
+				return await db.query.organizations.findFirst({
+					where: eq(organizations.name, name),
+				});
+			} catch (error) {
+				logger.error(LOG_MODULE, `Failed querying Organization with name '${name}'`, error);
+				throw new ServiceUnavailable();
+			}
+		},
+
+		/**
+		 * Finds an Organization by ID
+		 * @param {number} organizationId
+		 * @returns {Promise<Organization | undefined>}
+		 */
+		getOrganizationById: async (organizationId: number): Promise<Organization | undefined> => {
+			try {
+				return await db.query.organizations.findFirst({
+					where: eq(organizations.id, organizationId),
+				});
+			} catch (error) {
+				logger.error(LOG_MODULE, `Failed querying Organization with id '${organizationId}'`, error);
+				throw new ServiceUnavailable();
+			}
+		},
+
+		/**
+		 * Delete an Organization by ID
+		 * @param {number} organizationId
+		 */
+		delete: async (organizationId: number): Promise<void> => {
+			try {
+				await db.delete(organizations).where(eq(organizations.id, organizationId));
+				logger.info(LOG_MODULE, `Organization with id '${organizationId}' deleted successfully`);
+			} catch (error) {
+				logger.error(LOG_MODULE, `Failed deleting Organization with id '${organizationId}'`, error);
+				throw new ServiceUnavailable();
+			}
+		},
+	};
+};
+
+export default repository;

--- a/packages/data-provider/src/routers/organizationRouter.ts
+++ b/packages/data-provider/src/routers/organizationRouter.ts
@@ -1,0 +1,26 @@
+import { json, Router, urlencoded } from 'express';
+
+import { BaseDependencies } from '../config/config.js';
+import organizationController from '../controllers/organizationController.js';
+import { type AuthConfig, authMiddleware } from '../middleware/auth.js';
+
+const router = ({
+	baseDependencies,
+	authConfig,
+}: {
+	baseDependencies: BaseDependencies;
+	authConfig: AuthConfig;
+}): Router => {
+	const router = Router();
+	router.use(urlencoded({ extended: false }));
+	router.use(json());
+
+	router.use(authMiddleware(authConfig));
+
+	router.post('/', organizationController(baseDependencies).registerOrganization);
+	router.delete('/:id', organizationController(baseDependencies).deleteOrganization);
+
+	return router;
+};
+
+export default router;

--- a/packages/data-provider/src/services/organizationService.ts
+++ b/packages/data-provider/src/services/organizationService.ts
@@ -1,0 +1,91 @@
+import { isEmpty } from 'lodash-es';
+import { BaseDependencies } from '../config/config.js';
+
+import organizationRepository from '../repository/organizationRepository.js';
+import { Organization, NewOrganization } from '@overture-stack/lyric-data-model/models';
+
+const organizationService = (dependencies: BaseDependencies) => {
+	const LOG_MODULE = 'ORGANIZATION_SERVICE';
+	const { logger } = dependencies;
+
+	/**
+	 * Registers a new Organization if it does not already exist
+	 * @param name The organization name
+	 * @returns {Organization} The saved or existing organization
+	 */
+	const registerOrganization = async (name: string): Promise<Organization> => {
+		const orgRepo = organizationRepository(dependencies);
+
+		try {
+			const existingOrg = await orgRepo.getOrganizationByName(name);
+
+			if (!isEmpty(existingOrg)) {
+				logger.info(LOG_MODULE, `Organization '${name}' already exists`);
+				return existingOrg;
+			}
+
+			const newOrg: NewOrganization = {
+				name,
+			};
+
+			const savedOrg = await orgRepo.save(newOrg);
+
+			logger.info(LOG_MODULE, `Organization '${name}' registered successfully`);
+			return savedOrg;
+		} catch (error) {
+			logger.error(LOG_MODULE, `Error registering organization '${name}'`, error);
+			throw error;
+		}
+	};
+
+	/**
+	 * Deletes an existing Organization by ID
+	 * @param orgId The ID of the organization to delete
+	 * @returns boolean - true if deleted, false if not found
+	 */
+	const deleteOrganization = async (orgId: number): Promise<boolean> => {
+		const orgRepo = organizationRepository(dependencies);
+
+		try {
+			const existingOrg = await orgRepo.getOrganizationById(orgId);
+
+			if (!existingOrg) {
+				logger.warn(LOG_MODULE, `Organization with id '${orgId}' not found`);
+				return false;
+			}
+
+			await orgRepo.delete(orgId);
+			logger.info(LOG_MODULE, `Organization with id '${orgId}' deleted successfully`);
+
+			return true;
+		} catch (error) {
+			logger.error(LOG_MODULE, `Error deleting organization with id '${orgId}'`, error);
+			throw error;
+		}
+	};
+
+	/**
+	 * Retrieves an Organization by name
+	 * @param name The organization name
+	 * @returns {Organization | undefined} The organization if found, else undefined
+	 */
+	const getOrganizationByName = async (name: string): Promise<Organization | undefined> => {
+		const orgRepo = organizationRepository(dependencies);
+
+		try {
+			const organization = await orgRepo.getOrganizationByName(name);
+			return organization;
+		} catch (error) {
+			logger.error(LOG_MODULE, `Error fetching organization by name '${name}'`, error);
+			throw error;
+		}
+	};
+
+	return {
+		registerOrganization,
+		deleteOrganization,
+		getOrganizationByName,
+	};
+};
+
+export default organizationService;

--- a/packages/data-provider/src/utils/schemas.ts
+++ b/packages/data-provider/src/utils/schemas.ts
@@ -470,3 +470,17 @@ export const validationRequestSchema: RequestValidation<object, validationQueryP
 	query: validationQuerySchema,
 	pathParams: validationPathParamsSchema,
 };
+
+export const registerOrganizationSchema = {
+	body: z.object({
+		name: z.string().min(1, 'Organization name is required'),
+	}),
+};
+
+export const deleteOrganizationSchema = {
+	params: z.object({
+		id: z.string().regex(/^\d+$/, 'ID must be a number'),
+	}),
+	query: z.object({}),
+	body: z.object({}),
+};


### PR DESCRIPTION
<!-- PR Title Should match format:
#{TicketNumber}: Description of Changes


## Summary

This PR fixes issues in the /dictionary/register endpoint where:
The API incorrectly returned an error when defaultCentricEntity was supplied as an empty value.
The API truncated version numbers (e.g., 1.0 became 1).

## Issues
- #(issue number)
- #(issue number)

## Description of Changes
<!-- Describe the changes in your pull request **per service or package**, providing enough context for reviewers.

Be sure to call out any breaking changes, as well as any special instructions required to run the new code (i.e. New or updated dependencies? `pnpm i`. New migrations to run? `pnpm run migrate-dev`. etc.) 

Add a heading for each app/package that you have contributed changes to and list the changes included.
-->

<!-- EXAMPLE START
General description of the changes in your PR and the functionality it adds.

### UI
- Added a new component `ComponentName` which achieves some functionality.
  - Description of `ComponentName` and the changes you made to create it
  - Added package [`package name`](https://link.to/package) to handle something

### Server
- Added new endpoint `GET /stuff`that does stuff


### Special Instructions
Before running these changes, you will need to ...

-->

## Readiness Checklist

- [ ] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [ ] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [ ] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [ ] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
