### PR TITLE
#79: Enable auth to read data

### DIFF
--- a/packages/data-provider/README.md
+++ b/packages/data-provider/README.md
@@ -55,7 +55,7 @@ const lyricProvider = provider(appConfig);
 
 ### Auth Custom Handler
 
-The **authentication custom handler** is a customizable function that can be used to verify user authentication and grant write permissions to organizations. It is used by the auth middleware to process incoming requests before any operation is executed, and to identify the user for audit purposes on these endpoints.
+The **authentication custom handler** is a customizable function that can be used to verify user authentication and grant write and read permissions to organizations. It is used by the auth middleware to process incoming requests before any operation is executed, and to identify the user for audit purposes on these endpoints.
 
 The handler receives an argument of type `Request` and returns a `UserSessionResult` response type, which provides information about the user's session or any errors encountered during the process.
 
@@ -68,17 +68,28 @@ This result `UserSessionResult` object may include the following:
   		username: string;
   		isAdmin: boolean;
   		allowedWriteOrganizations: string[];
+  		allowedReadOrganizations: string[];
   	}
   ```
 
   - **username**: A string representing the user's identifier (e.g., email address).
   - **isAdmin**: A boolean value indicating whether the user has admin privileges. If `true`, the user has write access to all organizations.
-  - **allowedWriteOrganization**: An array of strings representing the organizations to which the user is allowed to write data.
+  - **allowedWriteOrganizations**: An array of strings representing the organizations to which the user is allowed to write data.
+  - **allowedReadOrganizations**: An array of strings representing the organizations to which the user is allowed to read data.
 
-  When an authentication error occurs, the system should return the following error details:
+When an authentication error occurs, the system should return the following error details:
 
 - **errorCode**: A numeric code representing an error that occurred while processing the session request.
 - **errorMessage**: A descriptive message detailing the specific error, if an errorCode is provided.
+
+> **Note:** To include additional properties in the `UserSession` object (for example: groups, department or any other application specific information), you can create a custom user session type that extends `UserSession`. Example:
+>
+> ```javascript
+> type CustomUserSession = UserSession & {
+>   department?: string;
+>   groups?: string[];
+> };
+> ```
 
 Example how to implement a custom auth handler:
 
@@ -87,7 +98,7 @@ import { type Request } from 'express';
 import { type UserSessionResult } from '@overture-stack/lyric';
 import jwt from 'jsonwebtoken';
 
-const authHandler = (req: Request): UserSessionResult => {
+const authHandler = (req: Request): UserSessionResult<CustomUserSession> => {
     // Extract the token from the request header
     const authHeader = req.headers['authorization'];
 
@@ -112,7 +123,9 @@ const authHandler = (req: Request): UserSessionResult => {
 			user: {
 				username: decodedToken.username, // Extract username from the decoded token
 				isAdmin: decodedToken.isAdmin, // Check if the user has admin privileges
-				allowedWriteOrganizations: decodedToken.scopes, // Get the list of organizations the user can write to
+				allowedWriteOrganizations: decodedToken.writeScopes, // Get the list of organizations the user can write to
+				allowedReadOrganizations: decodedToken.readScopes, // Get the list of organizations the user can read
+				groups: decodedToken.groups, // List of the groups the user is part of
 			 },
 		};
 	} catch (err) {

--- a/packages/data-provider/index.ts
+++ b/packages/data-provider/index.ts
@@ -1,7 +1,12 @@
 // config
 export { type AppConfig, type ValidatorEntry } from './src/config/config.js';
 export { default as provider } from './src/core/provider.js';
-export { type UserSession, type UserSessionResult } from './src/middleware/auth.js';
+export {
+	type AuthConfig,
+	type RequestWithUser,
+	type UserSession,
+	type UserSessionResult,
+} from './src/middleware/auth.js';
 export { errorHandler } from './src/middleware/errorHandler.js';
 export { type DbConfig, migrate } from '@overture-stack/lyric-data-model';
 

--- a/packages/data-provider/src/controllers/submittedDataController.ts
+++ b/packages/data-provider/src/controllers/submittedDataController.ts
@@ -4,7 +4,7 @@ import { convertToViewType } from '..//utils/submittedDataUtils.js';
 import { BaseDependencies } from '../config/config.js';
 import { type AuthConfig, shouldBypassAuth } from '../middleware/auth.js';
 import submittedDataService from '../services/submittedData/submmittedData.js';
-import { getUserReadableOrganizations } from '../utils/authUtils.js';
+import { getUserReadableOrganizations, hasUserReadAccess } from '../utils/authUtils.js';
 import { parseSQON } from '../utils/convertSqonToQuery.js';
 import { Forbidden, NotFound } from '../utils/errors.js';
 import { asArray } from '../utils/formatUtils.js';
@@ -49,10 +49,6 @@ const controller = ({
 					`pagination params: page '${page}' pageSize '${pageSize}'`,
 					`view '${view}'`,
 				);
-
-				if (!shouldBypassAuth(req, authConfig)) {
-					throw new Forbidden(`User is not authorized to read submitted data`);
-				}
 
 				const readableOrganizations = getUserReadableOrganizations(user);
 
@@ -101,11 +97,7 @@ const controller = ({
 					`view '${view}'`,
 				);
 
-				if (!shouldBypassAuth(req, authConfig)) {
-					throw new Forbidden(`User is not authorized to read submitted data`);
-				}
-
-				if (user?.isAdmin === false && !getUserReadableOrganizations(user)?.includes(organization)) {
+				if (!shouldBypassAuth(req, authConfig) && !hasUserReadAccess(organization, user)) {
 					throw new Forbidden(`User is not authorized to read submitted data for organization '${organization}'`);
 				}
 
@@ -160,11 +152,7 @@ const controller = ({
 					`pagination params: page '${page}' pageSize '${pageSize}'`,
 				);
 
-				if (!shouldBypassAuth(req, authConfig)) {
-					throw new Forbidden(`User is not authorized to read submitted data`);
-				}
-
-				if (user?.isAdmin === false && !getUserReadableOrganizations(user)?.includes(organization)) {
+				if (!shouldBypassAuth(req, authConfig) && !hasUserReadAccess(organization, user)) {
 					throw new Forbidden(`User is not authorized to read submitted data for organization '${organization}'`);
 				}
 
@@ -212,10 +200,6 @@ const controller = ({
 					`params: view '${view}'`,
 				);
 
-				if (!shouldBypassAuth(req, authConfig)) {
-					throw new Forbidden(`User is not authorized to read submitted data`);
-				}
-
 				const readableOrganizations = getUserReadableOrganizations(user);
 
 				const submittedDataResult = await service.getSubmittedDataBySystemId(categoryId, systemId, {
@@ -240,10 +224,6 @@ const controller = ({
 				const user = req.user;
 
 				logger.info(LOG_MODULE, `Request stream for submitted data on categoryId '${categoryId}'`);
-
-				if (!shouldBypassAuth(req, authConfig)) {
-					throw new Forbidden(`User is not authorized to read submitted data`);
-				}
 
 				const readableOrganizations = getUserReadableOrganizations(user);
 

--- a/packages/data-provider/src/controllers/submittedDataController.ts
+++ b/packages/data-provider/src/controllers/submittedDataController.ts
@@ -1,6 +1,5 @@
 import * as _ from 'lodash-es';
 
-import { convertToViewType } from '..//utils/submittedDataUtils.js';
 import { BaseDependencies } from '../config/config.js';
 import { type AuthConfig, shouldBypassAuth } from '../middleware/auth.js';
 import submittedDataService from '../services/submittedData/submmittedData.js';
@@ -15,6 +14,7 @@ import {
 	dataGetByQueryRequestSchema,
 	dataGetBySystemIdRequestSchema,
 } from '../utils/schemas.js';
+import { convertToViewType } from '../utils/submittedDataUtils.js';
 import { SubmittedDataPaginatedResponse, VIEW_TYPE } from '../utils/types.js';
 
 const controller = ({
@@ -50,12 +50,12 @@ const controller = ({
 					`view '${view}'`,
 				);
 
-				const readableOrganizations = getUserReadableOrganizations(user);
+				const organizations = getUserReadableOrganizations(user);
 
 				const submittedDataResult = await service.getSubmittedDataByCategory(
 					categoryId,
 					{ page, pageSize },
-					{ entityName, view, organizations: readableOrganizations },
+					{ entityName, view, organizations },
 				);
 
 				if (_.isEmpty(submittedDataResult.result)) {
@@ -231,7 +231,7 @@ const controller = ({
 
 				logger.info(LOG_MODULE, `Request stream for submitted data on categoryId '${categoryId}'`);
 
-				const readableOrganizations = getUserReadableOrganizations(user);
+				const organizations = getUserReadableOrganizations(user);
 
 				res.setHeader('Transfer-Encoding', 'chunked');
 				res.setHeader('Content-Type', 'application/x-ndjson');
@@ -239,7 +239,7 @@ const controller = ({
 				for await (const data of service.getSubmittedDataByCategoryStream(categoryId, {
 					view,
 					entityName,
-					organizations: readableOrganizations,
+					organizations,
 				})) {
 					res.write(JSON.stringify(data) + '\n');
 				}

--- a/packages/data-provider/src/core/provider.ts
+++ b/packages/data-provider/src/core/provider.ts
@@ -71,7 +71,7 @@ const provider = (configData: AppConfig) => {
 				baseDependencies: baseDeps,
 				authConfig: { enabled: configData.auth.enabled },
 			}),
-			submittedData: submittedDataController(baseDeps),
+			submittedData: submittedDataController({ baseDependencies: baseDeps, authConfig: configData.auth }),
 			validator: validationController({ baseDependencies: baseDeps, validatorConfig: configData.validator }),
 		},
 		services: {

--- a/packages/data-provider/src/middleware/auth.ts
+++ b/packages/data-provider/src/middleware/auth.ts
@@ -4,6 +4,7 @@ export type UserSession = {
 	username: string;
 	isAdmin: boolean;
 	allowedWriteOrganizations: string[];
+	allowedReadOrganizations: string[];
 };
 
 export type UserSessionResult = {

--- a/packages/data-provider/src/middleware/auth.ts
+++ b/packages/data-provider/src/middleware/auth.ts
@@ -7,24 +7,22 @@ export type UserSession = {
 	allowedReadOrganizations: string[];
 };
 
-export type UserSessionResult = {
-	user?: UserSession;
+export type UserSessionResult<TUser extends UserSession = UserSession> = {
+	user?: TUser;
 	errorCode?: number;
 	errorMessage?: string;
 };
 
-export type AuthConfig = {
+export type AuthConfig<TResult extends UserSessionResult = UserSessionResult> = {
 	enabled: boolean;
 	protectedMethods?: Array<'GET' | 'POST' | 'PUT' | 'DELETE'>;
-	customAuthHandler?: (req: Request) => UserSessionResult | Promise<UserSessionResult>;
+	customAuthHandler?: (req: Request) => TResult | Promise<TResult>;
 };
 
 // Extends the Request interface to include a custom `user` object
-declare module 'express-serve-static-core' {
-	interface Request {
-		user?: UserSession;
-	}
-}
+export type RequestWithUser<TUser extends UserSession = UserSession> = Request & {
+	user?: TUser;
+};
 
 /**
  * Determines whether the incoming request should bypass authentication,
@@ -58,7 +56,7 @@ export const shouldBypassAuth = (req: Request, authConfig: AuthConfig) => {
  * @returns
  */
 export const authMiddleware = (authConfig: AuthConfig) => {
-	return async (req: Request, res: Response, next: NextFunction) => {
+	return async (req: RequestWithUser, res: Response, next: NextFunction) => {
 		if (shouldBypassAuth(req, authConfig)) {
 			return next();
 		}

--- a/packages/data-provider/src/repository/submittedRepository.ts
+++ b/packages/data-provider/src/repository/submittedRepository.ts
@@ -221,18 +221,18 @@ const repository = (dependencies: BaseDependencies) => {
 		 * @param {PaginationOptions} paginationOptions Pagination properties
 		 * @param {object} filter Filter Options
 		 * @param {string[] | undefined} filter.entityNames Array of entity names to filter
-		 * @param {string[] | undefined} filter.organization Array of organizations to filter
+		 * @param {string[] | undefined} filter.organizations Array of organizations to filter
 		 * @returns The SubmittedData found
 		 */
 		getSubmittedDataByCategoryIdPaginated: async (
 			categoryId: number,
 			paginationOptions: PaginationOptions,
-			filter?: { entityNames?: string[]; organization?: string[] },
+			filter?: { entityNames?: string[]; organizations?: string[] },
 		): Promise<SubmittedDataResponse[]> => {
 			const { page, pageSize } = paginationOptions;
 
 			const filterEntityNameSql = filterByEntityNameArray(filter?.entityNames);
-			const filterOrganizationSql = filterByOrganizationArray(filter?.organization);
+			const filterOrganizationSql = filterByOrganizationArray(filter?.organizations);
 
 			try {
 				return await db.query.submittedData.findMany({
@@ -336,15 +336,15 @@ const repository = (dependencies: BaseDependencies) => {
 		 * @param {object} filter Filter options
 		 * @param {SQL | undefined} filter.sql SQL command
 		 * @param {string[] | undefined} filter.entityNames Array of entity names to filter
-		 * @param {string[] | undefined} filter.organization Organization name to filter
+		 * @param {string[] | undefined} filter.organizations Organization name to filter
 		 * @returns Total number of recourds
 		 */
 		getTotalRecordsByCategoryId: async (
 			categoryId: number,
-			filter?: { sql?: SQL; entityNames?: string[]; organization?: string[] },
+			filter?: { sql?: SQL; entityNames?: string[]; organizations?: string[] },
 		): Promise<number> => {
 			const filterEntityNameSql = filterByEntityNameArray(filter?.entityNames);
-			const filterOrganizationSql = filterByOrganizationArray(filter?.organization);
+			const filterOrganizationSql = filterByOrganizationArray(filter?.organizations);
 			try {
 				const resultCount = await db
 					.select({ total: count() })
@@ -404,16 +404,12 @@ const repository = (dependencies: BaseDependencies) => {
 		 * Query to retrieve an unique SubmittedData record searching by System ID
 		 * Returns a SubmittedData record if found. Otherwise returns undefined
 		 * @param {string} systemId
-		 * @param {string[] | undefined} organization Optional array of organizations to filter the data by. if not provided, no organization filter is applied.
 		 * @returns {Promise<SubmittedData | undefined>}
 		 */
-		getSubmittedDataBySystemId: async (
-			systemId: string,
-			organization?: string[],
-		): Promise<SubmittedData | undefined> => {
+		getSubmittedDataBySystemId: async (systemId: string): Promise<SubmittedData | undefined> => {
 			try {
 				return await db.query.submittedData.findFirst({
-					where: and(eq(submittedData.systemId, systemId), filterByOrganizationArray(organization)),
+					where: eq(submittedData.systemId, systemId),
 				});
 			} catch (error) {
 				logger.error(LOG_MODULE, `Failed querying SubmittedData by systemId '${systemId}'`, error);

--- a/packages/data-provider/src/routers/submittedDataRouter.ts
+++ b/packages/data-provider/src/routers/submittedDataRouter.ts
@@ -17,25 +17,28 @@ const router = ({
 
 	router.use(authMiddleware(authConfig));
 
-	router.get('/category/:categoryId', submittedDataController(baseDependencies).getSubmittedDataByCategory);
+	router.get(
+		'/category/:categoryId',
+		submittedDataController({ baseDependencies, authConfig }).getSubmittedDataByCategory,
+	);
 
 	router.get(
 		'/category/:categoryId/organization/:organization',
-		submittedDataController(baseDependencies).getSubmittedDataByOrganization,
+		submittedDataController({ baseDependencies, authConfig }).getSubmittedDataByOrganization,
 	);
 
 	router.post(
 		'/category/:categoryId/organization/:organization/query',
-		submittedDataController(baseDependencies).getSubmittedDataByQuery,
+		submittedDataController({ baseDependencies, authConfig }).getSubmittedDataByQuery,
 	);
 
 	router.get(
 		'/category/:categoryId/id/:systemId',
-		submittedDataController(baseDependencies).getSubmittedDataBySystemId,
+		submittedDataController({ baseDependencies, authConfig }).getSubmittedDataBySystemId,
 	);
 	router.get(
 		'/category/:categoryId/stream',
-		submittedDataController(baseDependencies).getSubmittedDataByCategoryStream,
+		submittedDataController({ baseDependencies, authConfig }).getSubmittedDataByCategoryStream,
 	);
 
 	return router;

--- a/packages/data-provider/src/services/submittedData/submmittedData.ts
+++ b/packages/data-provider/src/services/submittedData/submmittedData.ts
@@ -232,7 +232,7 @@ const submittedData = (dependencies: BaseDependencies) => {
 	const getSubmittedDataByCategory = async (
 		categoryId: number,
 		paginationOptions: PaginationOptions,
-		filterOptions: { entityName?: string[]; view: ViewType; organization?: string[] },
+		filterOptions: { entityName?: string[]; view: ViewType; organizations?: string[] },
 	): Promise<{
 		result: SubmittedDataResponse[];
 		metadata: { totalRecords: number; errorMessage?: string };
@@ -251,7 +251,7 @@ const submittedData = (dependencies: BaseDependencies) => {
 
 		let recordsPaginated = await getSubmittedDataByCategoryIdPaginated(categoryId, paginationOptions, {
 			entityNames: getEntityNamesFromFilterOptions(filterOptions, defaultCentricEntity),
-			organization: filterOptions.organization,
+			organizations: filterOptions.organizations,
 		});
 
 		if (recordsPaginated.length === 0) {
@@ -268,6 +268,7 @@ const submittedData = (dependencies: BaseDependencies) => {
 
 		const totalRecords = await getTotalRecordsByCategoryId(categoryId, {
 			entityNames: getEntityNamesFromFilterOptions(filterOptions, defaultCentricEntity),
+			organizations: filterOptions.organizations,
 		});
 
 		logger.info(LOG_MODULE, `Retrieved '${recordsPaginated.length}' Submitted data on categoryId '${categoryId}'`);
@@ -370,7 +371,6 @@ const submittedData = (dependencies: BaseDependencies) => {
 	 * @param systemId - The unique identifier for the system associated with the submitted data.
 	 * @param filterOptions - An object containing options for data representation.
 	 * @param filterOptions.view - The desired view type for the data representation, such as 'flat' or 'compound'.
-	 * @param filterOptions.organization - An optional array of organizations to filter the data by. if not provided, no organization filter is applied.
 	 * @returns A promise that resolves to an object containing:
 	 * - `result`: The fetched `SubmittedDataResponse`, or `undefined` if no data is found.
 	 * - `metadata`: An object containing metadata about the fetched data, including an optional `errorMessage` property.
@@ -378,13 +378,13 @@ const submittedData = (dependencies: BaseDependencies) => {
 	const getSubmittedDataBySystemId = async (
 		categoryId: number,
 		systemId: string,
-		filterOptions: { view: ViewType; organization?: string[] },
+		filterOptions: { view: ViewType },
 	): Promise<{
 		result: SubmittedDataResponse | undefined;
 		metadata: { errorMessage?: string };
 	}> => {
 		// get SubmittedData by SystemId
-		const foundRecord = await submittedDataRepo.getSubmittedDataBySystemId(systemId, filterOptions.organization);
+		const foundRecord = await submittedDataRepo.getSubmittedDataBySystemId(systemId);
 		logger.info(LOG_MODULE, `Found Submitted Data with system ID '${systemId}'`);
 
 		if (!foundRecord) {
@@ -450,7 +450,7 @@ const submittedData = (dependencies: BaseDependencies) => {
 	 */
 	async function* getSubmittedDataByCategoryStream(
 		categoryId: number,
-		filterOptions: { entityName?: string[]; view: ViewType; organization?: string[] },
+		filterOptions: { entityName?: string[]; view: ViewType; organizations?: string[] },
 	) {
 		const { getSubmittedDataByCategoryIdPaginated, getTotalRecordsByCategoryId } = submittedDataRepo;
 
@@ -468,7 +468,7 @@ const submittedData = (dependencies: BaseDependencies) => {
 
 		const totalRecords = await getTotalRecordsByCategoryId(categoryId, {
 			entityNames: getEntityNamesFromFilterOptions(filterOptions, defaultCentricEntity),
-			organization: filterOptions.organization,
+			organizations: filterOptions.organizations,
 		});
 
 		for (let x = 0, currentPage = 1; x < totalRecords; currentPage++) {
@@ -480,7 +480,7 @@ const submittedData = (dependencies: BaseDependencies) => {
 				},
 				{
 					entityNames: getEntityNamesFromFilterOptions(filterOptions, defaultCentricEntity),
-					organization: filterOptions.organization,
+					organizations: filterOptions.organizations,
 				},
 			);
 

--- a/packages/data-provider/src/utils/authUtils.ts
+++ b/packages/data-provider/src/utils/authUtils.ts
@@ -18,3 +18,22 @@ export const hasUserWriteAccess = (organization: string, user?: UserSession): bo
 
 	return user.allowedWriteOrganizations.includes(organization);
 };
+
+/**
+ * retrieves the list of organizations a user has read access to.
+ * @param user
+ * @returns
+ */
+export const getUserReadableOrganizations = (user?: UserSession) => {
+	if (!user) {
+		// no user info, authentication is not enabled, allow all access
+		return undefined;
+	}
+
+	if (user.isAdmin) {
+		// admin has access to all organizations
+		return undefined;
+	}
+
+	return user.allowedReadOrganizations;
+};

--- a/packages/data-provider/src/utils/authUtils.ts
+++ b/packages/data-provider/src/utils/authUtils.ts
@@ -1,6 +1,50 @@
 import type { UserSession } from '../middleware/auth.js';
 
 /**
+ * Retrieves the list of organizations a user has read access to.
+ * If the user is an admin, it returns undefined to indicate access to all organizations.
+ * If no user information is provided, it also returns undefined to allow all access (assuming authentication is not enabled).
+ * Otherwise, it returns the list of organizations the user is allowed to read from.
+ * @param organization
+ * @param user
+ * @returns
+ */
+export const getUserReadableOrganizations = (user?: UserSession) => {
+	if (!user) {
+		// no user info, authentication is not enabled, allow all access
+		return undefined;
+	}
+
+	if (user.isAdmin) {
+		// admin has access to all organizations
+		return undefined;
+	}
+
+	return user.allowedReadOrganizations;
+};
+
+/**
+ * checks if a user has read access to a specific organization.
+ * Returns true if the user has access, false otherwise.
+ * @param organization
+ * @param user
+ * @returns
+ */
+export const hasUserReadAccess = (organization: string, user?: UserSession): boolean => {
+	if (!user) {
+		// no user info, authentication is not enabled, deny access
+		return false;
+	}
+
+	if (user.isAdmin) {
+		// if user is admin should have access to read all organization
+		return true;
+	}
+
+	return user.allowedReadOrganizations.includes(organization);
+};
+
+/**
  * checks if a user has write access to a specific organization.
  * @param organization
  * @param user
@@ -17,23 +61,4 @@ export const hasUserWriteAccess = (organization: string, user?: UserSession): bo
 	}
 
 	return user.allowedWriteOrganizations.includes(organization);
-};
-
-/**
- * retrieves the list of organizations a user has read access to.
- * @param user
- * @returns
- */
-export const getUserReadableOrganizations = (user?: UserSession) => {
-	if (!user) {
-		// no user info, authentication is not enabled, allow all access
-		return undefined;
-	}
-
-	if (user.isAdmin) {
-		// admin has access to all organizations
-		return undefined;
-	}
-
-	return user.allowedReadOrganizations;
 };

--- a/packages/data-provider/src/utils/requestValidation.ts
+++ b/packages/data-provider/src/utils/requestValidation.ts
@@ -1,6 +1,9 @@
-import { RequestHandler } from 'express-serve-static-core';
+import { NextFunction, Request, Response } from 'express';
+import type { ParamsDictionary, RequestHandler } from 'express-serve-static-core';
+import type { ParsedQs } from 'qs';
 import { ZodError, ZodSchema } from 'zod';
 
+import type { UserSession } from '../middleware/auth.js';
 import { BadRequest, InternalServerError } from './errors.js';
 
 export declare type RequestValidation<TBody, TQuery, TParams> = {
@@ -9,14 +12,25 @@ export declare type RequestValidation<TBody, TQuery, TParams> = {
 	pathParams?: ZodSchema<TParams>;
 };
 
+type RequestWithUser<
+	TParams extends ParamsDictionary = ParamsDictionary,
+	TBody = unknown,
+	TQuery extends ParsedQs = ParsedQs,
+> = Request<TParams, unknown, TBody, TQuery> & {
+	user?: UserSession;
+};
 /**
  * Validate the body using Zod parse
  * @param schema Zod objects used to validate request
  * @returns Throws a Bad Request when validation fails
  */
-export function validateRequest<TBody, TQuery, TParams>(
+export function validateRequest<
+	TBody,
+	TQuery extends ParsedQs = ParsedQs,
+	TParams extends ParamsDictionary = ParamsDictionary,
+>(
 	schema: RequestValidation<TBody, TQuery, TParams>,
-	handler: RequestHandler<TParams, unknown, TBody, TQuery>,
+	handler: (req: RequestWithUser<TParams, TBody, TQuery>, res: Response, next: NextFunction) => unknown,
 ): RequestHandler<TParams, unknown, TBody, TQuery> {
 	const LOG_MODULE = 'REQUEST_VALIDATION';
 	return async (req, res, next) => {


### PR DESCRIPTION
## Summary
Adding auth check to GET submitted Data endpoints.

## Issues
- https://github.com/Pan-Canadian-Genome-Library/Roadmap/issues/79

## Description of Changes
- **[Submitted Data Controller]:** When `auth` is enabled, the **GET Submitted Data** endpoints use the `User` session object to determine which organizations a user can access, based on the `allowedReadOrganizations` property. The response will only include data from organizations the user is permitted to read.
- **[Submitted Data Repository]:** Included a filter by `organization`. When provided it fetches data only by that organization, if not provided it fetches from any organiation.

### Error Response types:
- **403 Forbidden:** When user is not authenticated
- **403 Forbidden:** When user is not an admin and is requesting data for an organization that doesn't have access to.

## Readiness Checklist

- [X] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [X] **Formatting**
  - Code follows the project style guide
  - Automated code formatters (ie. Prettier) have been run
- [X] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [X] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [X] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
