### PR TITLE
#67: Resolve missing username in createdBy and updatedBy fields in register dictionary

### DIFF
--- a/packages/data-provider/src/repository/categoryRepository.ts
+++ b/packages/data-provider/src/repository/categoryRepository.ts
@@ -143,11 +143,11 @@ const repository = (dependencies: BaseDependencies) => {
 		 * @param newData Set fields to update
 		 * @returns The updated record
 		 */
-		update: async (categoryId: number, newData: Partial<Category>, username?: string): Promise<Category> => {
+		update: async (categoryId: number, newData: Partial<Category>): Promise<Category> => {
 			try {
 				const updated = await db
 					.update(dictionaryCategories)
-					.set({ ...newData, updatedAt: new Date(), updatedBy: username })
+					.set({ ...newData, updatedAt: new Date() })
 					.where(eq(dictionaryCategories.id, categoryId))
 					.returning();
 				return updated[0];

--- a/packages/data-provider/src/services/dictionaryService.ts
+++ b/packages/data-provider/src/services/dictionaryService.ts
@@ -135,14 +135,11 @@ const dictionaryService = (dependencies: BaseDependencies) => {
 			return { dictionary: savedDictionary, category: foundCategory };
 		} else if (foundCategory && foundCategory.activeDictionaryId !== savedDictionary.id) {
 			// Update the dictionary on existing Category
-			const updatedCategory = await categoryRepo.update(
-				foundCategory.id,
-				{
-					activeDictionaryId: savedDictionary.id,
-					defaultCentricEntity,
-				},
-				username,
-			);
+			const updatedCategory = await categoryRepo.update(foundCategory.id, {
+				activeDictionaryId: savedDictionary.id,
+				defaultCentricEntity,
+				updatedBy: username,
+			});
 
 			logger.info(
 				LOG_MODULE,


### PR DESCRIPTION
## Summary

Insert username in createdBy and updatedBy fields when a user registers a dictionary

## Issues
- https://github.com/Pan-Canadian-Genome-Library/clinical-submission/issues/67

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [x] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
