### PR TITLE
get submissions list summary

### DIFF
--- a/apps/server/swagger/schemas.yml
+++ b/apps/server/swagger/schemas.yml
@@ -243,21 +243,24 @@ components:
             inserts:
               type: object
               additionalProperties:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ValidationError'
+                type: object
+                properties:
+                  recordsCount:
+                    type: number
             updates:
               type: object
               additionalProperties:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ValidationError'
+                type: object
+                properties:
+                  recordsCount:
+                    type: number
             deletes:
               type: object
               additionalProperties:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ValidationError'
+                type: object
+                properties:
+                  recordsCount:
+                    type: number
         organization:
           type: string
           description: Organization the Submission belongs to

--- a/packages/data-provider/src/services/submission/submission.ts
+++ b/packages/data-provider/src/services/submission/submission.ts
@@ -11,9 +11,9 @@ import submittedRepository from '../../repository/submittedRepository.js';
 import { getSchemaByName } from '../../utils/dictionaryUtils.js';
 import { BadRequest, InternalServerError, StatusConflict } from '../../utils/errors.js';
 import {
+	createSubmissionSummaryResponse,
 	isSubmissionActive,
 	parseSubmissionResponse,
-	parseSubmissionSummaryResponse,
 	removeItemsFromSubmission,
 } from '../../utils/submissionUtils.js';
 import {
@@ -25,7 +25,7 @@ import {
 	SUBMISSION_ACTION_TYPE,
 	SUBMISSION_STATUS,
 	type SubmissionActionType,
-	SubmissionSummaryResponse,
+	SubmissionSummary,
 } from '../../utils/types.js';
 import processor from './processor.js';
 
@@ -258,12 +258,17 @@ const service = (dependencies: BaseDependencies) => {
 			organization?: string;
 		},
 	): Promise<{
-		result: SubmissionSummaryResponse[];
+		result: SubmissionSummary[];
 		metadata: { totalRecords: number; errorMessage?: string };
 	}> => {
-		const { getSubmissionsWithRelationsByCategory, getTotalSubmissionsByCategory } = submissionRepository(dependencies);
+		const { getSubmissionsSummaryWithRelationsByCategory, getTotalSubmissionsByCategory } =
+			submissionRepository(dependencies);
 
-		const recordsPaginated = await getSubmissionsWithRelationsByCategory(categoryId, paginationOptions, filterOptions);
+		const recordsPaginated = await getSubmissionsSummaryWithRelationsByCategory(
+			categoryId,
+			paginationOptions,
+			filterOptions,
+		);
 		if (!recordsPaginated || recordsPaginated.length === 0) {
 			return {
 				result: [],
@@ -278,7 +283,7 @@ const service = (dependencies: BaseDependencies) => {
 			metadata: {
 				totalRecords,
 			},
-			result: recordsPaginated.map((response) => parseSubmissionSummaryResponse(response)),
+			result: recordsPaginated.map((response) => createSubmissionSummaryResponse(response)),
 		};
 	};
 
@@ -314,7 +319,7 @@ const service = (dependencies: BaseDependencies) => {
 		categoryId: number;
 		username: string;
 		organization: string;
-	}): Promise<SubmissionSummaryResponse | undefined> => {
+	}): Promise<SubmissionSummary | undefined> => {
 		const { getActiveSubmissionWithRelationsByOrganization } = submissionRepository(dependencies);
 
 		const submission = await getActiveSubmissionWithRelationsByOrganization({ organization, username, categoryId });
@@ -322,7 +327,7 @@ const service = (dependencies: BaseDependencies) => {
 			return;
 		}
 
-		return parseSubmissionSummaryResponse(submission);
+		return createSubmissionSummaryResponse(submission);
 	};
 
 	/**

--- a/packages/data-provider/src/utils/types.ts
+++ b/packages/data-provider/src/utils/types.ts
@@ -211,6 +211,10 @@ export type DataDeletesSubmissionSummary = {
 	recordsCount: number;
 };
 
+export type DataErrorsSubmissionSummary = {
+	recordsCount: number;
+};
+
 export type DictionaryActiveSubmission = {
 	name: string;
 	version: string;
@@ -238,22 +242,49 @@ export type SubmissionResponse = {
 	updatedBy: string;
 };
 
-/**
- * Response type of Get Submission by Organization Endpoint
- * override 'data' object to contain a summary of records
- */
-export type SubmissionSummaryResponse = Omit<SubmissionResponse, 'data'> & {
-	data: {
-		inserts?: Record<string, DataInsertsSubmissionSummary>;
-		updates?: Record<string, DataUpdatesSubmissionSummary>;
-		deletes?: Record<string, DataDeletesSubmissionSummary>;
-	};
+export type SubmissionDataSummary = {
+	inserts?: Record<string, DataInsertsSubmissionSummary>;
+	updates?: Record<string, DataUpdatesSubmissionSummary>;
+	deletes?: Record<string, DataDeletesSubmissionSummary>;
+};
+
+export type SubmissionErrorsSummary = {
+	inserts?: Record<string, DataErrorsSubmissionSummary>;
+	updates?: Record<string, DataErrorsSubmissionSummary>;
+	deletes?: Record<string, DataErrorsSubmissionSummary>;
 };
 
 /**
- * Retrieve Submission object from repository
+ * Shortened version of the Submission record that omits the data changes and error details
+ * in favour of the count of records changed and errors for each entity type.
  */
-export type SubmissionSummaryRepository = {
+export type SubmissionSummary = Omit<SubmissionResponse, 'data' | 'errors'> & {
+	data: SubmissionDataSummary;
+} & {
+	errors: SubmissionErrorsSummary;
+};
+
+/**
+ * Retrieve Submission object with data summary from repository
+ */
+export type SubmissionSummaryRepositoryRecord = {
+	id: number;
+	data: SubmissionDataSummary;
+	dictionary: Pick<Dictionary, 'name' | 'version'>;
+	dictionaryCategory: Pick<Category, 'id' | 'name'>;
+	errors: SubmissionErrorsSummary;
+	organization: string | null;
+	status: SubmissionStatus | null;
+	createdAt: Date | null;
+	createdBy: string | null;
+	updatedAt: Date | null;
+	updatedBy: string | null;
+};
+
+/**
+ * Retrieve Submission object with data summary from repository
+ */
+export type SubmissionRepositoryRecord = {
 	id: number;
 	data: SubmissionData;
 	dictionary: Pick<Dictionary, 'name' | 'version'>;

--- a/packages/data-provider/test/utils/submission/parseSubmissionResponse.spec.ts
+++ b/packages/data-provider/test/utils/submission/parseSubmissionResponse.spec.ts
@@ -5,12 +5,12 @@ import type { DataRecord } from '@overture-stack/lectern-client';
 
 import { createBatchResponse } from '../../../src/utils/submissionResponseParser.js';
 import { parseSubmissionResponse } from '../../../src/utils/submissionUtils.js';
-import { SUBMISSION_STATUS, type SubmissionSummaryRepository } from '../../../src/utils/types.js';
+import { SUBMISSION_STATUS, type SubmissionRepositoryRecord } from '../../../src/utils/types.js';
 
 describe('Submission Utils - Parse a Submisison object to a response format', () => {
 	const todaysDate = new Date();
 	it('return a Submission response with no data', () => {
-		const SubmissionSummaryRepository: SubmissionSummaryRepository = {
+		const submissionRepositoryRecord: SubmissionRepositoryRecord = {
 			id: 2,
 			data: {},
 			dictionary: { name: 'books', version: '1' },
@@ -23,7 +23,7 @@ describe('Submission Utils - Parse a Submisison object to a response format', ()
 			updatedAt: null,
 			updatedBy: null,
 		};
-		const response = parseSubmissionResponse(SubmissionSummaryRepository);
+		const response = parseSubmissionResponse(submissionRepositoryRecord);
 		expect(response).to.eql({
 			id: 2,
 			data: {},
@@ -39,7 +39,7 @@ describe('Submission Utils - Parse a Submisison object to a response format', ()
 		});
 	});
 	it('return a Submission response format with insert, update and delete data', () => {
-		const SubmissionSummaryRepository: SubmissionSummaryRepository = {
+		const submissionRepositoryRecord: SubmissionRepositoryRecord = {
 			id: 2,
 			data: {
 				inserts: {
@@ -83,7 +83,7 @@ describe('Submission Utils - Parse a Submisison object to a response format', ()
 			updatedAt: null,
 			updatedBy: null,
 		};
-		const response = parseSubmissionResponse(SubmissionSummaryRepository);
+		const response = parseSubmissionResponse(submissionRepositoryRecord);
 		expect(response).to.eql({
 			id: 2,
 			data: {

--- a/packages/data-provider/test/utils/submission/parseSubmissionSummaryResponse.spec.ts
+++ b/packages/data-provider/test/utils/submission/parseSubmissionSummaryResponse.spec.ts
@@ -1,15 +1,19 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { parseSubmissionSummaryResponse } from '../../../src/utils/submissionUtils.js';
-import { SUBMISSION_STATUS, type SubmissionSummaryRepository } from '../../../src/utils/types.js';
+import { createSubmissionSummaryResponse } from '../../../src/utils/submissionUtils.js';
+import { SUBMISSION_STATUS, type SubmissionSummaryRepositoryRecord } from '../../../src/utils/types.js';
 
 describe('Submission Utils - Parse a Submission object to a Summary of the Active Submission', () => {
 	const todaysDate = new Date();
 	it('should return a Summary without any data ', () => {
-		const SubmissionSummaryRepository: SubmissionSummaryRepository = {
+		const submissionSummaryRepositoryRecord: SubmissionSummaryRepositoryRecord = {
 			id: 4,
-			data: {},
+			data: {
+				inserts: undefined,
+				updates: undefined,
+				deletes: undefined,
+			},
 			dictionary: { name: 'books', version: '1' },
 			dictionaryCategory: { name: 'favorite books', id: 1 },
 			errors: {},
@@ -20,7 +24,7 @@ describe('Submission Utils - Parse a Submission object to a Summary of the Activ
 			updatedAt: null,
 			updatedBy: null,
 		};
-		const response = parseSubmissionSummaryResponse(SubmissionSummaryRepository);
+		const response = createSubmissionSummaryResponse(submissionSummaryRepositoryRecord);
 		expect(response).to.eql({
 			id: 4,
 			data: {
@@ -40,38 +44,24 @@ describe('Submission Utils - Parse a Submission object to a Summary of the Activ
 		});
 	});
 	it('should return a Summary with insert, update and delete data ', () => {
-		const SubmissionSummaryRepository: SubmissionSummaryRepository = {
+		const submissionSummaryRepositoryRecord: SubmissionSummaryRepositoryRecord = {
 			id: 3,
 			data: {
 				inserts: {
 					books: {
 						batchName: 'books.tsv',
-						records: [
-							{
-								title: 'abc',
-							},
-						],
+						recordsCount: 1,
 					},
 				},
 				updates: {
-					books: [
-						{
-							systemId: 'QWE987',
-							new: { title: 'The Little Prince' },
-							old: { title: 'the little prince' },
-						},
-					],
+					books: {
+						recordsCount: 1,
+					},
 				},
 				deletes: {
-					books: [
-						{
-							systemId: 'ZXC678',
-							entityName: 'books',
-							organization: 'oicr',
-							isValid: true,
-							data: { title: 'batman' },
-						},
-					],
+					books: {
+						recordsCount: 1,
+					},
 				},
 			},
 			dictionary: { name: 'books', version: '1' },
@@ -84,7 +74,7 @@ describe('Submission Utils - Parse a Submission object to a Summary of the Activ
 			updatedAt: null,
 			updatedBy: null,
 		};
-		const response = parseSubmissionSummaryResponse(SubmissionSummaryRepository);
+		const response = createSubmissionSummaryResponse(submissionSummaryRepositoryRecord);
 		expect(response).to.eql({
 			id: 3,
 			data: {


### PR DESCRIPTION
# Description
This PR updates how `recordsCount` is calculated for submission `data` and `errors` fields, moving the logic to a DB query approach to improve response time.

Also updates the GET submissions list endpoint (`GET /submission/category/{categoryId}`) response to return a `errors` summary per submission, instead of the full errors payload. 

## Additional details
- Additional code refactoring (rename variables and functions for readibility)
- Updated Swagger specs
- Updated tests