### PR TITLE
Build app using Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG WORKDIR=/usr/src/app
 ######################
 # Configure base image
 ######################
-FROM node:20.12.2-alpine AS base
+FROM node:22-alpine AS base
 
 ARG APP_USER
 ARG WORKDIR
@@ -14,15 +14,15 @@ ARG WORKDIR
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 
-# install pnpm as root user, before updating node ownership
-RUN npm i -g pnpm
-
 # create our own user to run node, don't run node in production as root
 ENV APP_UID=9999
 ENV APP_GID=9999
 RUN addgroup -S -g $APP_GID $APP_USER \
 	&& adduser -S -u $APP_UID -g $APP_GID $APP_USER \
 	&& mkdir -p ${WORKDIR}
+
+RUN corepack enable
+RUN corepack use pnpm@11.1.1
 
 WORKDIR ${WORKDIR}
 
@@ -34,14 +34,15 @@ USER ${APP_USER}:${APP_USER}
 # Configure build image
 ######################
 
-FROM base as build
+FROM base AS build
 
 ARG APP_USER
 ARG WORKDIR
 
-COPY --chown=lyric:lyric . ./
+COPY --chown=${APP_USER}:${APP_USER} . ./
+USER ${APP_USER}:${APP_USER}
 
-RUN pnpm install --ignore-scripts
+RUN pnpm install --ignore-scripts --frozen-lockfile
 
 RUN pnpm build:all
 
@@ -62,7 +63,7 @@ USER ${APP_USER}:${APP_USER}
 ENV CI=true
 
 # pnpm will not install any package listed in devDependencies
-RUN pnpm install --prod
+RUN pnpm install --prod --no-scripts --frozen-lockfile
 
 
 ######################
@@ -73,12 +74,12 @@ FROM base AS server
 ARG APP_USER
 ARG WORKDIR
 
-USER ${APP_USER}
+USER ${APP_USER}:${APP_USER}
 
 WORKDIR ${WORKDIR}
 
-COPY --from=prod-deps ${WORKDIR} .
-COPY --from=build ${WORKDIR}/apps/server/dist apps/server/dist
+COPY --from=prod-deps --chown=${APP_USER}:${APP_USER} ${WORKDIR} .
+COPY --from=build --chown=${APP_USER}:${APP_USER} ${WORKDIR}/apps/server/dist apps/server/dist
 
 EXPOSE 3000
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,10 @@ packages:
   - 'apps/*'
   # all packages in subdirs of packages/
   - 'packages/*'
+allowBuilds:
+  '@scarf/scarf': false
+  cpu-features: false
+  es5-ext: false
+  esbuild: false
+  protobufjs: false
+  ssh2: false


### PR DESCRIPTION
## Summary
**pnpm 11.x** requires **Node 22+**, so this PR updates the build environment to meet that requirement and keep installs working consistently.

## Description of Changes
- Updated `./Dockerfile` base image to Node 22.
- Updated `./Dockerfile` to use corepack `pnpm 11.1.1`.
- Updated `./pnpm-workspace.yaml` to add `allowBuilds` entries