### PR TITLE
fix: surface file parse errors with fault isolation and structured logging

### DIFF
--- a/.dev/tech-debt.md
+++ b/.dev/tech-debt.md
@@ -4,7 +4,7 @@
 
 ### Tests live in `test/` not co-located with source
 standalone: yes
-context: Convention mismatch: team convention is to co-locate test files with source (`validation.test.ts` next to `validation.ts`). Lyric's existing mocha suite lives in `packages/data-provider/test/`. New tests should be co-located. Migrating existing tests is a standalone cleanup task.
+context: Convention mismatch, two parts: team convention is to co-locate test files with source (`validation.test.ts` next to `validation.ts`), using the `.test.ts` suffix. Lyric's existing suite instead lives entirely under `packages/data-provider/test/{unit,integration}/` (49 spec files total, e.g. `test/unit/external/kafkaPublisher.spec.ts`), using `.spec.ts`. Fix: relocate each spec file into the same directory as the source file it tests, renaming `.spec.ts` to `.test.ts` to match convention. New tests should be co-located from now on; migrating the existing 49 is a standalone cleanup task, not in scope of feature work.
 
 ### Existing tests use mocha/chai/sinon, not node:test
 standalone: no
@@ -20,7 +20,7 @@ context: When `producer.send` fails after all kafkajs retries, the commit is com
 
 ### Server logger not passed into AppConfig
 standalone: yes
-context: `server.ts` creates a logger with `getLogger()` and `buildAppConfig()` creates a second one internally from `LoggerConfig`. The lyric provider should use the server's logger instance rather than constructing its own. Requires either `AppConfig` to accept a `Logger` instance (not just `LoggerConfig`), or a way to inject it post-construction. Flagged by Jon in PR #208.
+context: `server.ts` creates a logger with `getLogger()` and `buildAppConfig()` creates a second one internally from `LoggerConfig`. The lyric provider should use the server's logger instance rather than constructing its own. Requires either `AppConfig` to accept a `Logger` instance (not just `LoggerConfig`), or a way to inject it post-construction. Flagged in PR #208 review.
 
 ### Base image has known high vulnerability
 standalone: yes
@@ -33,4 +33,4 @@ context: `FROM node:22-alpine` (Dockerfile line 9) is flagged with a high CVE by
 <!-- Move entries here when addressed, with a note of when and what fixed it -->
 
 ### Kafka publish tracking: no unit tests for `createPublishTracker`
-resolved: tracker removed in PR #208 (published_at column dropped on Jon's review; tracking responsibility deferred)
+resolved: tracker removed in PR #208 (published_at column dropped during review; tracking responsibility deferred)

--- a/apps/server/src/config/app.ts
+++ b/apps/server/src/config/app.ts
@@ -61,6 +61,7 @@ export const buildAppConfig = (overrides: Partial<AppConfig> = {}): AppConfig =>
 		customSize: Number(process.env.ID_CUSTOM_SIZE) || 21,
 	},
 	logger: {
+		json: getBoolean(process.env.LOG_JSON, false),
 		level: process.env.LOG_LEVEL || 'info',
 	},
 	schemaService: {

--- a/apps/server/src/config/app.ts
+++ b/apps/server/src/config/app.ts
@@ -61,6 +61,7 @@ export const buildAppConfig = (overrides: Partial<AppConfig> = {}): AppConfig =>
 		customSize: Number(process.env.ID_CUSTOM_SIZE) || 21,
 	},
 	logger: {
+		file: getBoolean(process.env.LOG_FILE, false),
 		json: getBoolean(process.env.LOG_JSON, false),
 		level: process.env.LOG_LEVEL || 'info',
 	},

--- a/apps/server/swagger/submission-api.yml
+++ b/apps/server/swagger/submission-api.yml
@@ -279,6 +279,20 @@
     parameters:
       - $ref: '#/components/parameters/path/CategoryId'
       - $ref: '#/components/parameters/query/Organization'
+      - name: sync
+        in: query
+        required: false
+        schema:
+          type: string
+          enum: [true, false]
+          default: 'false'
+        description: >
+          Controls whether file parsing is synchronous. When `false` (default), parsing runs in the
+          background and `fileResults` will be empty in the response. When `true`, the response waits
+          for all files to be parsed and returns per-file results in `fileResults`.
+
+          **Warning:** Using `sync=true` on very large batches may cause the request to time out before
+          the response is returned. Monitor server logs for parse errors when using the default async mode.
     requestBody:
       description: File(s) to be added to the submission, with an optional mapping of filenames to entity names.
       required: true

--- a/packages/data-provider/.mocharc.json
+++ b/packages/data-provider/.mocharc.json
@@ -1,6 +1,6 @@
 {
 	"extension": ["ts"],
-	"spec": ["test/unit/**/*.spec.ts", "test/integration/**/*.spec.ts"],
+	"spec": ["src/**/*.spec.ts", "test/unit/**/*.spec.ts", "test/integration/**/*.spec.ts"],
 	"node-option": ["import=tsx"],
 	"timeout": 35000
 }

--- a/packages/data-provider/README.md
+++ b/packages/data-provider/README.md
@@ -42,6 +42,7 @@ const appConfig: AppConfig = {
 		customSize: 12, // Size of the generated ID
 	},
 	logger: {
+		file: false, // When true, writes a plain-text log to logs.log (legacy). Controlled by LOG_FILE env var.
 		json: false, // When true, writes a structured JSON log to logs/app.json for log aggregator ingestion (e.g. Kibana). Controlled by LOG_JSON env var.
 		level: 'info', // Logging level (e.g., 'debug', 'info', 'warn', 'error'). Controlled by LOG_LEVEL env var.
 	},

--- a/packages/data-provider/README.md
+++ b/packages/data-provider/README.md
@@ -42,7 +42,8 @@ const appConfig: AppConfig = {
 		customSize: 12, // Size of the generated ID
 	},
 	logger: {
-		level: 'info', // Logging level (e.g., 'debug', 'info', 'warn', 'error')
+		json: false, // When true, writes a structured JSON log to logs/app.json for log aggregator ingestion (e.g. Kibana). Controlled by LOG_JSON env var.
+		level: 'info', // Logging level (e.g., 'debug', 'info', 'warn', 'error'). Controlled by LOG_LEVEL env var.
 	},
 	schemaService: {
 		url: 'https://api.lectern-service.com', // URL of the schema service
@@ -202,6 +203,28 @@ const app = express();
 
 app.use('/submission', lyricProvider.routers.submission);
 ```
+
+### File Submission
+
+Files are submitted via `POST /submission/category/:categoryId/files` as a multipart form upload.
+
+By default, parsing runs in the background and `fileResults` will be empty in the response. Pass `sync=true` to wait for parsing and receive per-file results in the response.
+
+| `fileResults[].status` | Meaning |
+|---|---|
+| `ok` | File parsed successfully with no schema validation errors. |
+| `invalid` | File parsed but contains schema validation errors. The submission still proceeds; errors are listed in `parseErrors` (field names and line numbers only). |
+| `error` | File could not be read or parsed at all (e.g. corrupt stream, bad encoding). No records from this file were stored. |
+
+**`sync` query parameter**
+
+By default (`sync=false`), the endpoint returns immediately and parsing runs in the background. Pass `sync=true` to wait for results:
+
+```
+POST /submission/category/1/files?sync=true
+```
+
+When `sync=true`, `fileResults` will be populated in the response with per-file outcomes. Without it, parse errors are logged on the server but not returned to the caller. Avoid `sync=true` on very large batches where parsing time would exceed your client's request timeout.
 
 ### Provider Shut down
 

--- a/packages/data-provider/src/config/config.ts
+++ b/packages/data-provider/src/config/config.ts
@@ -30,8 +30,9 @@ export type SubmissionServiceConfig = {
 };
 
 export type LoggerConfig = {
-	level?: string;
 	file?: boolean;
+	json?: boolean;
+	level?: string;
 };
 
 export type IdServiceConfig = {

--- a/packages/data-provider/src/config/logger.ts
+++ b/packages/data-provider/src/config/logger.ts
@@ -65,7 +65,7 @@ export const getLogger = (config: LoggerConfig): Logger => {
 		}),
 	);
 
-	// Plain-text file transport (legacy; kept for backwards compatibility).
+	// Plain-text file transport for pre-Kubernetes deployments that relied on file-based log shipping.
 	if (config.file) {
 		transportList.push(new transports.File({ filename: 'logs.log' }));
 	}

--- a/packages/data-provider/src/config/logger.ts
+++ b/packages/data-provider/src/config/logger.ts
@@ -1,4 +1,4 @@
-import { createLogger, format, LoggerOptions, transports } from 'winston';
+import { createLogger, format, transports } from 'winston';
 
 import { LoggerConfig } from './config.js';
 
@@ -12,29 +12,58 @@ export type Logger = {
 };
 
 /**
- * Get a Logger instance for log messages
- * @param config logger configuration
- * @returns functions to log messages based on each log level
+ * Splits a variadic argument list into a message string and optional structured metadata object.
+ * When the last argument is a plain object (not an Error, array, or null), it is treated as metadata.
+ */
+const splitArgs = (messages: unknown[]): { message: string; meta?: Record<string, unknown> } => {
+	const last = messages[messages.length - 1];
+	const isMetaObject =
+		last !== null &&
+		last !== undefined &&
+		typeof last === 'object' &&
+		!Array.isArray(last) &&
+		!(last instanceof Error);
+	if (isMetaObject && messages.length > 1) {
+		return { message: messages.slice(0, -1).join(' - '), meta: last as Record<string, unknown> };
+	}
+	return { message: messages.join(' - ') };
+};
+
+/** Renders a metadata object as `key=value` pairs for human-readable console output. */
+const metaToString = (meta: Record<string, unknown>): string =>
+	Object.entries(meta)
+		.map(([k, v]) => `${k}=${typeof v === 'string' ? v : JSON.stringify(v)}`)
+		.join(' ');
+
+/**
+ * Get a Logger instance for log messages.
+ * Console transport emits human-readable `key=value` metadata.
+ * When `config.json` is true, a separate JSON file transport writes structured logs to `logs/app.json`
+ * for ingestion by log aggregators (e.g. Kibana).
  */
 export const getLogger = (config: LoggerConfig): Logger => {
-	const transportList: LoggerOptions['transports'] = [];
+	const { combine, timestamp, colorize, errors, json, printf } = format;
 
-	const { combine, timestamp, colorize, printf } = format;
-
-	// console transport
-	const consoleLog = new transports.Console({
+	const consoleTransport = new transports.Console({
 		format: combine(
+			errors({ stack: true }),
 			timestamp(),
 			colorize(),
-			printf(({ timestamp, level, message }) => `${timestamp} [${level}]: ${message}`),
+			printf(({ timestamp, level, message, meta }) => {
+				const metaPart = meta ? ` ${metaToString(meta as Record<string, unknown>)}` : '';
+				return `${timestamp} [${level}]: ${message}${metaPart}`;
+			}),
 		),
 	});
-	transportList.push(consoleLog);
 
-	// file transport
-	if (config.file) {
-		const fileLog = new transports.File({ filename: 'logs.log' });
-		transportList.push(fileLog);
+	const transportList = [consoleTransport];
+
+	if (config.json) {
+		const jsonTransport = new transports.File({
+			filename: 'logs/app.json',
+			format: combine(errors({ stack: true }), timestamp(), json()),
+		});
+		transportList.push(jsonTransport);
 	}
 
 	const logger = createLogger({
@@ -42,23 +71,17 @@ export const getLogger = (config: LoggerConfig): Logger => {
 		transports: transportList,
 	});
 
-	const log = (...message: unknown[]) => {
-		const fullMessage = message.join(' - ');
-		return fullMessage;
-	};
+	const emit =
+		(fn: (message: string, meta?: object) => void) =>
+		(...messages: unknown[]) => {
+			const { message, meta } = splitArgs(messages);
+			fn(message, meta ? { meta } : undefined);
+		};
 
 	return {
-		debug: (...messages: unknown[]) => {
-			return logger.debug(log(...messages));
-		},
-		warn: (...messages: unknown[]) => {
-			return logger.warn(log(...messages));
-		},
-		info: (...messages: unknown[]) => {
-			return logger.info(log(...messages));
-		},
-		error: (...messages: unknown[]) => {
-			return logger.error(log(...messages));
-		},
+		debug: emit((msg, meta) => logger.debug(msg, meta)),
+		warn: emit((msg, meta) => logger.warn(msg, meta)),
+		info: emit((msg, meta) => logger.info(msg, meta)),
+		error: emit((msg, meta) => logger.error(msg, meta)),
 	};
 };

--- a/packages/data-provider/src/config/logger.ts
+++ b/packages/data-provider/src/config/logger.ts
@@ -1,4 +1,4 @@
-import { createLogger, format, transports } from 'winston';
+import { createLogger, format, transport, transports } from 'winston';
 
 import { LoggerConfig } from './config.js';
 
@@ -12,24 +12,26 @@ export type Logger = {
 };
 
 /**
- * Splits a variadic argument list into a message string and optional structured metadata object.
- * When the last argument is a plain object (not an Error, array, or null), it is treated as metadata.
+ * Splits variadic logger arguments into a text message and an optional metadata object.
+ * If the last argument is a plain object it is treated as structured metadata; all preceding
+ * arguments are joined with ' - ' to form the message string.
  */
 const splitArgs = (messages: unknown[]): { message: string; meta?: Record<string, unknown> } => {
 	const last = messages[messages.length - 1];
 	const isMetaObject =
-		last !== null &&
-		last !== undefined &&
-		typeof last === 'object' &&
-		!Array.isArray(last) &&
-		!(last instanceof Error);
+		last !== null && last !== undefined && typeof last === 'object' && !Array.isArray(last) && !(last instanceof Error);
+
 	if (isMetaObject && messages.length > 1) {
-		return { message: messages.slice(0, -1).join(' - '), meta: last as Record<string, unknown> };
+		return {
+			message: messages.slice(0, -1).join(' - '),
+			meta: last as Record<string, unknown>,
+		};
 	}
+
 	return { message: messages.join(' - ') };
 };
 
-/** Renders a metadata object as `key=value` pairs for human-readable console output. */
+/** Renders a metadata object as space-separated key=value pairs for human-readable output. */
 const metaToString = (meta: Record<string, unknown>): string =>
 	Object.entries(meta)
 		.map(([k, v]) => `${k}=${typeof v === 'string' ? v : JSON.stringify(v)}`)
@@ -37,33 +39,45 @@ const metaToString = (meta: Record<string, unknown>): string =>
 
 /**
  * Get a Logger instance for log messages.
- * Console transport emits human-readable `key=value` metadata.
- * When `config.json` is true, a separate JSON file transport writes structured logs to `logs/app.json`
- * for ingestion by log aggregators (e.g. Kibana).
+ *
+ * Supports two transports:
+ * - Console: human-readable `timestamp [level]: message key=value ...` format, always active.
+ * - JSON file (`logs/app.json`): full structured JSON for log aggregators; enabled via `config.json`.
  */
 export const getLogger = (config: LoggerConfig): Logger => {
-	const { combine, timestamp, colorize, errors, json, printf } = format;
+	const transportList: transport[] = [];
 
-	const consoleTransport = new transports.Console({
-		format: combine(
-			errors({ stack: true }),
-			timestamp(),
-			colorize(),
-			printf(({ timestamp, level, message, meta }) => {
-				const metaPart = meta ? ` ${metaToString(meta as Record<string, unknown>)}` : '';
-				return `${timestamp} [${level}]: ${message}${metaPart}`;
-			}),
-		),
-	});
+	const { combine, timestamp, colorize, printf, json, errors } = format;
 
-	const transportList = [consoleTransport];
+	// Console transport: human-readable with metadata rendered as key=value pairs.
+	transportList.push(
+		new transports.Console({
+			format: combine(
+				timestamp(),
+				colorize(),
+				errors({ stack: true }),
+				printf(({ timestamp, level, message, ...meta }) => {
+					const metaKeys = Object.keys(meta).filter((k) => k !== 'stack');
+					const metaStr = metaKeys.length ? ' ' + metaToString(meta as Record<string, unknown>) : '';
+					return `${timestamp} [${level}]: ${message}${metaStr}`;
+				}),
+			),
+		}),
+	);
 
+	// Plain-text file transport (legacy; kept for backwards compatibility).
+	if (config.file) {
+		transportList.push(new transports.File({ filename: 'logs.log' }));
+	}
+
+	// JSON file transport for log aggregators (Kibana via Filebeat, etc.).
 	if (config.json) {
-		const jsonTransport = new transports.File({
-			filename: 'logs/app.json',
-			format: combine(errors({ stack: true }), timestamp(), json()),
-		});
-		transportList.push(jsonTransport);
+		transportList.push(
+			new transports.File({
+				filename: 'logs/app.json',
+				format: combine(timestamp(), errors({ stack: true }), json()),
+			}),
+		);
 	}
 
 	const logger = createLogger({
@@ -75,13 +89,13 @@ export const getLogger = (config: LoggerConfig): Logger => {
 		(fn: (message: string, meta?: object) => void) =>
 		(...messages: unknown[]) => {
 			const { message, meta } = splitArgs(messages);
-			fn(message, meta ? { meta } : undefined);
+			fn(message, meta);
 		};
 
 	return {
-		debug: emit((msg, meta) => logger.debug(msg, meta)),
-		warn: emit((msg, meta) => logger.warn(msg, meta)),
-		info: emit((msg, meta) => logger.info(msg, meta)),
-		error: emit((msg, meta) => logger.error(msg, meta)),
+		debug: emit(logger.debug.bind(logger)),
+		warn: emit(logger.warn.bind(logger)),
+		info: emit(logger.info.bind(logger)),
+		error: emit(logger.error.bind(logger)),
 	};
 };

--- a/packages/data-provider/src/controllers/submissionController.ts
+++ b/packages/data-provider/src/controllers/submissionController.ts
@@ -389,6 +389,7 @@ const controller = ({
 				const files = Array.isArray(req.files) ? req.files : [];
 				const organization = req.query.organization;
 				const fileEntityMap = req.body;
+				const sync = req.query.sync === 'true';
 				// Get username from auth
 				const username = req.user?.username || '';
 
@@ -438,6 +439,7 @@ const controller = ({
 					organization,
 					username,
 					fileEntityMap,
+					sync,
 				});
 
 				if (submitFilesResult.status === 'UNKNOWN_CATEGORY') {

--- a/packages/data-provider/src/services/submission/submissionProcessor.ts
+++ b/packages/data-provider/src/services/submission/submissionProcessor.ts
@@ -24,6 +24,7 @@ import { convertRecordToString } from '../../utils/formatUtils.js';
 import { parseRecordsToInsert } from '../../utils/recordsParser.js';
 import {
 	extractSchemaDataFromMergedDataRecords,
+	type FileParseResult,
 	filterDeletesFromUpdates,
 	filterRelationsForPrimaryIdUpdate,
 	findEditSubmittedData,
@@ -810,17 +811,40 @@ const createSubmissionProcessor = (dependencies: BaseDependencies) => {
 		return updatedActiveSubmissionId;
 	};
 
+	const logFileResults = (fileResults: FileParseResult[]) => {
+		for (const result of fileResults) {
+			if (result.status === 'error') {
+				logger.error(LOG_MODULE, `Failed to parse file`, {
+					fileName: result.fileName,
+					entityName: result.entityName,
+					error: result.streamError,
+				});
+			} else if (result.status === 'invalid') {
+				// Log field names and line numbers only — not field values (OWASP A03).
+				logger.warn(LOG_MODULE, `File parsed with schema validation issues`, {
+					fileName: result.fileName,
+					entityName: result.entityName,
+					errorCount: result.parseErrors.length,
+					issues: result.parseErrors.slice(0, 10).map((e) => ({
+						line: e.recordIndex,
+						fields: e.recordErrors.map((re) => re.fieldName),
+					})),
+				});
+			}
+		}
+	};
+
 	/**
-	 * Void function to process and validate uploaded files on an Active Submission.
-	 * Performs the schema data validation combined with all Submitted Data.
-	 * @param {Record<string, { files: Express.Multer.File[], schema: Schema }>} fileSchemaMap Mapping the files with a schema
-	 * @param {Object} params
-	 * @param {number} params.categoryId Category Identifier
-	 * @param {string} params.organization Organization name
-	 * @param {string} params.username User who performs the action
-	 * @returns {void}
+	 * Processes and validates uploaded files on an Active Submission.
+	 * File parsing is fault-isolated per file. Schema validation runs in a background worker thread.
+	 * @param {FileSchemaMap} fileSchemaMap Mapping of files to their resolved entity and schema
+	 * @param {ValidateFilesParams} params categoryId, organization, username
+	 * @returns Per-file parse results, available immediately; validation results arrive later via the worker.
 	 */
-	const addFilesToSubmissionAsync = async (fileSchemaMap: FileSchemaMap, params: ValidateFilesParams) => {
+	const addFilesToSubmissionAsync = async (
+		fileSchemaMap: FileSchemaMap,
+		params: ValidateFilesParams,
+	): Promise<FileParseResult[]> => {
 		const fileSummaries = Object.entries(fileSchemaMap)
 			.flatMap(([_, { files, schema }]) =>
 				files.map(
@@ -830,13 +854,14 @@ const createSubmissionProcessor = (dependencies: BaseDependencies) => {
 			.join(', ');
 		logger.info(LOG_MODULE, `Processing files: ${fileSummaries}`);
 
-		// TODO: This only gets a summary, we need to insert data into an active submission so we need all the insert statements.
-
 		const { categoryId, organization, username } = params;
+		let fileResults: FileParseResult[] = [];
 
 		try {
-			// Parse file data
-			const filesDataProcessed = await submissionInsertDataFromFiles(fileSchemaMap);
+			// Parse file data — each file is isolated; a failure on one does not block others.
+			const { data: filesDataProcessed, fileResults: parsed } = await submissionInsertDataFromFiles(fileSchemaMap);
+			fileResults = parsed;
+			logFileResults(fileResults);
 
 			// Get Active Submission from database
 			const activeSubmission = await submissionRepository.getActiveSubmissionDetails({
@@ -845,7 +870,7 @@ const createSubmissionProcessor = (dependencies: BaseDependencies) => {
 				organization,
 			});
 			if (!activeSubmission) {
-				throw new BadRequest(`Submission '${activeSubmission}' not found`);
+				throw new BadRequest(`No active submission found for category '${categoryId}' organization '${organization}'`);
 			}
 
 			// Merge Active Submission data with incoming TSV file data processed
@@ -865,12 +890,18 @@ const createSubmissionProcessor = (dependencies: BaseDependencies) => {
 			// Perform Schema Data validation in a worker thread
 			dependencies.workerPool.dataValidation({ submissionId: activeSubmission.id });
 		} catch (error) {
-			logger.error(`There was an error processing submitted files: ${fileSummaries}`, JSON.stringify(error));
+			logger.error(LOG_MODULE, `Error processing submitted files`, {
+				files: fileSummaries,
+				error: error instanceof Error ? error.message : String(error),
+				errorType: error instanceof Error ? error.name : 'unknown',
+			});
 		}
 		logger.info(
 			LOG_MODULE,
 			`Finished addFilesToSubmissionAsync for active submission in category "${params.categoryId}" for organization "${params.organization}" submitted by user "${params.username}"`,
 		);
+
+		return fileResults;
 	};
 
 	return {

--- a/packages/data-provider/src/services/submission/submissionProcessor.ts
+++ b/packages/data-provider/src/services/submission/submissionProcessor.ts
@@ -858,12 +858,7 @@ const createSubmissionProcessor = (dependencies: BaseDependencies) => {
 		let fileResults: FileParseResult[] = [];
 
 		try {
-			// Parse file data — each file is isolated; a failure on one does not block others.
-			const { data: filesDataProcessed, fileResults: parsed } = await submissionInsertDataFromFiles(fileSchemaMap);
-			fileResults = parsed;
-			logFileResults(fileResults);
-
-			// Get Active Submission from database
+			// Verify an active submission exists before doing any parsing work.
 			const activeSubmission = await submissionRepository.getActiveSubmissionDetails({
 				categoryId,
 				username,
@@ -872,6 +867,11 @@ const createSubmissionProcessor = (dependencies: BaseDependencies) => {
 			if (!activeSubmission) {
 				throw new BadRequest(`No active submission found for category '${categoryId}' organization '${organization}'`);
 			}
+
+			// Parse file data — each file is isolated; a failure on one does not block others.
+			const { data: filesDataProcessed, fileResults: parsed } = await submissionInsertDataFromFiles(fileSchemaMap);
+			fileResults = parsed;
+			logFileResults(fileResults);
 
 			// Merge Active Submission data with incoming TSV file data processed
 			const insertActiveSubmissionData = mergeInsertsRecords(activeSubmission.data.inserts ?? {}, filesDataProcessed);

--- a/packages/data-provider/src/services/submission/submissionService.ts
+++ b/packages/data-provider/src/services/submission/submissionService.ts
@@ -14,6 +14,7 @@ import { filterAndPaginateSubmissionData, type FlattenedSubmissionData } from '.
 import {
 	checkEntityFieldNames,
 	createSubmissionSummaryResponse,
+	type FileParseResult,
 	isSubmissionActive,
 	removeItemsFromSubmission,
 	resolveFileEntities,
@@ -503,12 +504,14 @@ const submissionService = (dependencies: BaseDependencies) => {
 		organization,
 		username,
 		fileEntityMap,
+		sync = false,
 	}: {
 		files: Express.Multer.File[];
 		categoryId: number;
 		organization: string;
 		username: string;
 		fileEntityMap?: FilenameEntityPair[];
+		sync?: boolean;
 	}): Promise<SubmitFileResult | UnknownCategoryResult> => {
 		logger.info(LOG_MODULE, `Processing '${files.length}' files on category id '${categoryId}'`);
 
@@ -517,6 +520,7 @@ const submissionService = (dependencies: BaseDependencies) => {
 				status: ACTIVE_SUBMISSION_STATUS.INVALID_SUBMISSION,
 				description: 'No valid files for submission',
 				batchErrors: [],
+				fileResults: [],
 				inProcessEntities: [],
 			};
 		}
@@ -559,6 +563,7 @@ const submissionService = (dependencies: BaseDependencies) => {
 				status: ACTIVE_SUBMISSION_STATUS.INVALID_SUBMISSION,
 				description: 'No valid entities in submission',
 				batchErrors,
+				fileResults: [],
 				inProcessEntities: entitiesToProcess,
 			};
 		}
@@ -573,6 +578,7 @@ const submissionService = (dependencies: BaseDependencies) => {
 					status: ACTIVE_SUBMISSION_STATUS.INVALID_SUBMISSION,
 					description: error.message,
 					batchErrors: [],
+					fileResults: [],
 					inProcessEntities: [],
 				};
 			}
@@ -582,14 +588,15 @@ const submissionService = (dependencies: BaseDependencies) => {
 		// TODO: Add files to submission, then run validation separately. Currently these processes are both
 		//       done by the function that adds the files to the submission.
 
-		// Start background process of adding files to submission
-		// Running Schema validation in the background do not need to wait
-		// Result of validations will be stored in database
-		submissionProcessor.addFilesToSubmissionAsync(checkedEntities, {
+		// Parsing always starts immediately. When sync=true (default) the response waits for results;
+		// when sync=false it runs in the background and fileResults will be empty in the response.
+		// Schema validation always runs in a background worker thread regardless of this flag.
+		const parsePromise = submissionProcessor.addFilesToSubmissionAsync(checkedEntities, {
 			categoryId,
 			organization,
 			username,
 		});
+		const fileResults: FileParseResult[] = sync ? await parsePromise : [];
 
 		if (batchErrors.length === 0) {
 			return {
@@ -597,6 +604,7 @@ const submissionService = (dependencies: BaseDependencies) => {
 				description: 'Submission files are being processed',
 				submissionId: activeSubmissionId,
 				batchErrors,
+				fileResults,
 				inProcessEntities: entitiesToProcess,
 			};
 		}
@@ -606,6 +614,7 @@ const submissionService = (dependencies: BaseDependencies) => {
 			description: 'Some Submission files are being processed while others were unable to process',
 			submissionId: activeSubmissionId,
 			batchErrors,
+			fileResults,
 			inProcessEntities: entitiesToProcess,
 		};
 	};

--- a/packages/data-provider/src/services/submission/submissionService.ts
+++ b/packages/data-provider/src/services/submission/submissionService.ts
@@ -490,13 +490,9 @@ const submissionService = (dependencies: BaseDependencies) => {
 	};
 
 	/**
-	 * Validates and Creates the Entities Schemas of the Active Submission and stores it in the database
-	 * @param {object} params
-	 * @param {Express.Multer.File[]} params.files An array of files
-	 * @param {number} params.categoryId Category ID of the Submission
-	 * @param {string} params.organization Organization name
-	 * @param {string} params.username User name creating the Submission
-	 * @returns The Active Submission created or Updated
+	 * Validates the uploaded files against the active submission's entity schemas and stores
+	 * the parsed records in the database. When `sync` is true, awaits parsing and returns
+	 * per-file results; when false (default), parsing runs in the background.
 	 */
 	const submitFiles = async ({
 		files,

--- a/packages/data-provider/src/utils/fileUtils.ts
+++ b/packages/data-provider/src/utils/fileUtils.ts
@@ -44,14 +44,8 @@ export const getSeparatorCharacter = (file: Express.Multer.File): string | undef
  * @returns An `UnprocessedDataRecord` object where each header in `headers` is a key,
  *          and each value is the corresponding entry in `record` formatted for compatibility.
  */
-export const mapRecordToHeaders = (headers: string[], record: string[]) => {
-	return headers.reduce((obj: UnprocessedDataRecord, nextKey, index) => {
-		const dataStr = record[index] || '';
-		const formattedData = formatForExcelCompatibility(dataStr);
-		obj[nextKey] = formattedData;
-		return obj;
-	}, {});
-};
+export const mapRecordToHeaders = (headers: string[], record: string[]): UnprocessedDataRecord =>
+	Object.fromEntries(headers.map((key, index) => [key, formatForExcelCompatibility(record[index] || '')]));
 
 /**
  * Reads only first line of the file
@@ -63,74 +57,52 @@ export const readHeaders = async (file: Express.Multer.File) => {
 	return firstline(file.path);
 };
 
+/** Collects all raw rows from a delimited file stream, then cleans up the temp file. */
+const collectRows = (filePath: string, separator: string): Promise<string[][]> =>
+	new Promise((resolve, reject) => {
+		const rows: string[][] = [];
+		const stream = fs.createReadStream(filePath).pipe(csvParse({ delimiter: separator }));
+		stream.on('data', (row: string[]) => rows.push(row));
+		stream.on('end', () => resolve(rows));
+		stream.on('error', (err) => reject(err));
+		stream.on('close', () => {
+			stream.destroy();
+			fs.unlink(filePath, () => {});
+		});
+	});
+
 /**
- * Reads a text file and parse it to a JSON format.
- * Records are parsed to match schema field types.
- * Supported files: .tsv and .csv
- * @param {Express.Multer.File} file A file to read
- * @param {Schema} schema Schema to parse data with
- * @returns a JSON format objet
+ * Reads a text file and parses it to typed records.
+ * Returns all records (valid or not) and a separate list of per-row schema validation errors.
+ * Supported file types: .tsv and .csv
  */
 export const readTextFile = async (
 	file: Express.Multer.File,
 	schema: Schema,
-): Promise<{ records: DataRecord[]; errors?: ParseSchemaError[] }> => {
-	const returnRecords: DataRecord[] = [];
-	const returnErrors: ParseSchemaError[] = [];
-	const separatorCharacter = getSeparatorCharacter(file);
-	if (!separatorCharacter) {
-		throw new Error('Invalid file Extension');
+): Promise<{ records: DataRecord[]; errors: ParseSchemaError[] }> => {
+	const separator = getSeparatorCharacter(file);
+	if (!separator) {
+		throw new Error('Invalid file extension');
 	}
 
-	let headers: string[] = [];
-	let lineNumber = 0;
+	const rows = await collectRows(file.path, separator);
+	const [headerRow, ...dataRows] = rows;
+	if (!headerRow) {
+		return { records: [], errors: [] };
+	}
+	const headers = Object.values(headerRow);
 
-	return new Promise((resolve, reject) => {
-		const stream = fs.createReadStream(file.path).pipe(csvParse({ delimiter: separatorCharacter }));
-
-		stream.on('data', (record: string[]) => {
-			lineNumber++;
-			if (!headers.length) {
-				headers = Object.values(record);
-			} else {
-				const mappedRecord = mapRecordToHeaders(headers, record);
-
-				try {
-					const parseSchemaResult = parse.parseRecordValues(mappedRecord, schema);
-					if (parseSchemaResult.success) {
-						returnRecords.push(parseSchemaResult.data.record);
-					} else {
-						returnRecords.push(parseSchemaResult.data.record);
-						returnErrors.push({
-							recordErrors: parseSchemaResult.data.errors,
-							recordIndex: lineNumber,
-						});
-					}
-
-					if (lineNumber % 1000 === 0) {
-						// TODO: Add batch processing logic here (e.g., write to database or process as needed)
-						// returnRecords = []; // Clear the array after processing the batch
-						// returnErrors = []; // Clear the array after processing the batch
-					}
-				} catch (error) {
-					console.error(`Catching error parsing data: ${error}`);
-				}
-			}
-		});
-
-		stream.on('end', () => {
-			resolve({ records: returnRecords, errors: returnErrors });
-		});
-
-		stream.on('close', () => {
-			stream.destroy();
-			fs.unlink(file.path, () => {});
-		});
-
-		stream.on('error', () => {
-			reject({ records: returnRecords, errors: returnErrors });
-		});
+	const parsed = dataRows.map((row, index) => {
+		const lineNumber = index + 2; // +1 for header row, +1 for 1-based line numbers
+		const result = parse.parseRecordValues(mapRecordToHeaders(headers, row), schema);
+		const error = result.success ? undefined : { recordErrors: result.data.errors, recordIndex: lineNumber };
+		return { record: result.data.record, error };
 	});
+
+	return {
+		records: parsed.map((p) => p.record),
+		errors: parsed.flatMap((p) => (p.error ? [p.error] : [])),
+	};
 };
 
 function formatForExcelCompatibility(data: string) {
@@ -170,51 +142,55 @@ type FileProcessingResult = {
 	fileErrors: BatchError[];
 };
 
-/**
- * Processes an array of uploaded files, filtering valid `.tsv` files and checking for required headers
- *
- * @param {Express.Multer.File[]} files An array of `Express.Multer.File` objects representing the uploaded files.
- * @returns A `Promise<FileProcessingResult>` that resolves to an object containing two arrays:
- * - `validFiles`: Files that have a `.tsv` extension and contain the `systemId` header.
- * - `fileErrors`: Files that either have an invalid extension or are missing the required `systemId` header.
- */
-export async function processFiles(files: Express.Multer.File[]): Promise<FileProcessingResult> {
-	const result: FileProcessingResult = {
-		validFiles: [],
-		fileErrors: [],
-	};
+type FileOutcome = { valid: true; file: Express.Multer.File } | { valid: false; error: BatchError };
 
-	for (const file of files) {
-		try {
-			if (getSubmittedFileType(file).success) {
-				const fileHeaders = await readHeaders(file); // Wait for the async operation
-				if (fileHeaders.includes('systemId')) {
-					result.validFiles.push(file);
-				} else {
-					const batchError: BatchError = {
-						type: BATCH_ERROR_TYPE.MISSING_REQUIRED_HEADER,
-						message: `File '${file.originalname}' is missing the column 'systemId'`,
-						batchName: file.originalname,
-					};
-					result.fileErrors.push(batchError);
-				}
-			} else {
-				const batchError: BatchError = {
+const classifyFile = async (file: Express.Multer.File): Promise<FileOutcome> => {
+	try {
+		if (!getSubmittedFileType(file).success) {
+			return {
+				valid: false,
+				error: {
 					type: BATCH_ERROR_TYPE.INVALID_FILE_EXTENSION,
 					message: `File '${file.originalname}' has invalid file extension. File extension must be '${SUPPORTED_FILE_EXTENSIONS.options}'`,
 					batchName: file.originalname,
+				},
+			};
+		}
+		const headers = await readHeaders(file);
+		return headers.includes('systemId')
+			? { valid: true, file }
+			: {
+					valid: false,
+					error: {
+						type: BATCH_ERROR_TYPE.MISSING_REQUIRED_HEADER,
+						message: `File '${file.originalname}' is missing the column 'systemId'`,
+						batchName: file.originalname,
+					},
 				};
-				result.fileErrors.push(batchError);
-			}
-		} catch (error) {
-			const batchError: BatchError = {
+	} catch {
+		return {
+			valid: false,
+			error: {
 				type: BATCH_ERROR_TYPE.FILE_READ_ERROR,
 				message: `Error reading file '${file.originalname}'`,
 				batchName: file.originalname,
-			};
-			result.fileErrors.push(batchError);
-		}
+			},
+		};
 	}
+};
 
-	return result;
-}
+/**
+ * Validates an array of uploaded files in parallel, checking extension and required headers.
+ *
+ * @param {Express.Multer.File[]} files An array of `Express.Multer.File` objects representing the uploaded files.
+ * @returns A `Promise<FileProcessingResult>` that resolves to an object containing two arrays:
+ * - `validFiles`: Files that have a valid extension and contain the `systemId` header.
+ * - `fileErrors`: Files that either have an invalid extension or are missing the required `systemId` header.
+ */
+export const processFiles = async (files: Express.Multer.File[]): Promise<FileProcessingResult> => {
+	const outcomes = await Promise.all(files.map(classifyFile));
+	return {
+		validFiles: outcomes.filter((o): o is { valid: true; file: Express.Multer.File } => o.valid).map((o) => o.file),
+		fileErrors: outcomes.filter((o): o is { valid: false; error: BatchError } => !o.valid).map((o) => o.error),
+	};
+};

--- a/packages/data-provider/src/utils/fileUtils.ts
+++ b/packages/data-provider/src/utils/fileUtils.ts
@@ -61,12 +61,19 @@ export const readHeaders = async (file: Express.Multer.File) => {
 const collectRows = (filePath: string, separator: string): Promise<string[][]> =>
 	new Promise((resolve, reject) => {
 		const rows: string[][] = [];
-		const stream = fs.createReadStream(filePath).pipe(csvParse({ delimiter: separator }));
-		stream.on('data', (row: string[]) => rows.push(row));
-		stream.on('end', () => resolve(rows));
-		stream.on('error', (err) => reject(err));
-		stream.on('close', () => {
-			stream.destroy();
+		const source = fs.createReadStream(filePath);
+		const parser = source.pipe(csvParse({ delimiter: separator }));
+		// source errors (e.g. ENOENT, EACCES) fire on the ReadStream and do NOT propagate
+		// through pipe() to the transform. Without this, a missing file causes an unhandled
+		// rejection that escapes the try/catch in the caller.
+		source.on('error', (err) => reject(err));
+		parser.on('data', (row: string[]) => rows.push(row));
+		parser.on('end', () => resolve(rows));
+		// parser errors (e.g. malformed CSV) fire on the transform stream, not the source.
+		parser.on('error', (err) => reject(err));
+		parser.on('close', () => {
+			parser.destroy();
+			source.destroy();
 			fs.unlink(filePath, () => {});
 		});
 	});

--- a/packages/data-provider/src/utils/fileUtils.ts
+++ b/packages/data-provider/src/utils/fileUtils.ts
@@ -13,6 +13,7 @@ import {
 } from '@overture-stack/lectern-client';
 
 import { getSubmittedFileType } from '../services/submission/submissionFile.js';
+import { failure, success, type Result } from './result.js';
 import { BATCH_ERROR_TYPE, type BatchError } from './types.js';
 
 export const SUPPORTED_FILE_EXTENSIONS = z.enum(['tsv', 'csv']);
@@ -149,55 +150,40 @@ type FileProcessingResult = {
 	fileErrors: BatchError[];
 };
 
-type FileOutcome = { valid: true; file: Express.Multer.File } | { valid: false; error: BatchError };
-
-const classifyFile = async (file: Express.Multer.File): Promise<FileOutcome> => {
+const classifyFile = async (file: Express.Multer.File): Promise<Result<Express.Multer.File, BatchError>> => {
 	try {
 		if (!getSubmittedFileType(file).success) {
-			return {
-				valid: false,
-				error: {
-					type: BATCH_ERROR_TYPE.INVALID_FILE_EXTENSION,
-					message: `File '${file.originalname}' has invalid file extension. File extension must be '${SUPPORTED_FILE_EXTENSIONS.options}'`,
-					batchName: file.originalname,
-				},
-			};
+			return failure({
+				type: BATCH_ERROR_TYPE.INVALID_FILE_EXTENSION,
+				message: `File '${file.originalname}' has invalid file extension. File extension must be '${SUPPORTED_FILE_EXTENSIONS.options}'`,
+				batchName: file.originalname,
+			});
 		}
 		const headers = await readHeaders(file);
 		return headers.includes('systemId')
-			? { valid: true, file }
-			: {
-					valid: false,
-					error: {
-						type: BATCH_ERROR_TYPE.MISSING_REQUIRED_HEADER,
-						message: `File '${file.originalname}' is missing the column 'systemId'`,
-						batchName: file.originalname,
-					},
-				};
+			? success(file)
+			: failure({
+					type: BATCH_ERROR_TYPE.MISSING_REQUIRED_HEADER,
+					message: `File '${file.originalname}' is missing the column 'systemId'`,
+					batchName: file.originalname,
+				});
 	} catch {
-		return {
-			valid: false,
-			error: {
-				type: BATCH_ERROR_TYPE.FILE_READ_ERROR,
-				message: `Error reading file '${file.originalname}'`,
-				batchName: file.originalname,
-			},
-		};
+		return failure({
+			type: BATCH_ERROR_TYPE.FILE_READ_ERROR,
+			message: `Error reading file '${file.originalname}'`,
+			batchName: file.originalname,
+		});
 	}
 };
 
 /**
  * Validates an array of uploaded files in parallel, checking extension and required headers.
- *
- * @param {Express.Multer.File[]} files An array of `Express.Multer.File` objects representing the uploaded files.
- * @returns A `Promise<FileProcessingResult>` that resolves to an object containing two arrays:
- * - `validFiles`: Files that have a valid extension and contain the `systemId` header.
- * - `fileErrors`: Files that either have an invalid extension or are missing the required `systemId` header.
+ * Returns files that passed validation and batch errors for those that did not.
  */
 export const processFiles = async (files: Express.Multer.File[]): Promise<FileProcessingResult> => {
 	const outcomes = await Promise.all(files.map(classifyFile));
 	return {
-		validFiles: outcomes.filter((o): o is { valid: true; file: Express.Multer.File } => o.valid).map((o) => o.file),
-		fileErrors: outcomes.filter((o): o is { valid: false; error: BatchError } => !o.valid).map((o) => o.error),
+		validFiles: outcomes.filter((o) => o.success).map((o) => o.data),
+		fileErrors: outcomes.filter((o) => !o.success).map((o) => o.data),
 	};
 };

--- a/packages/data-provider/src/utils/schemas.ts
+++ b/packages/data-provider/src/utils/schemas.ts
@@ -1,6 +1,6 @@
 import type { ParamsDictionary } from 'express-serve-static-core';
 import type { ParsedQs } from 'qs';
-import { z } from 'zod';
+import { z as zod } from 'zod';
 
 import type { DataRecord } from '@overture-stack/lectern-client';
 import type { SQON } from '@overture-stack/sqon-builder';
@@ -11,20 +11,20 @@ import { isValidDateFormat, isValidIdNumber } from './formatUtils.js';
 import { RequestValidation } from './requestValidation.js';
 import { VIEW_TYPE } from './types.js';
 
-const auditEventTypeSchema = z
+const auditEventTypeSchema = zod
 	.string()
 	.trim()
 	.min(1)
 	.refine((value) => isAuditEventValid(value), 'invalid Event Type');
 
-const booleanSchema = z
+const booleanSchema = zod
 	.string()
 	.toLowerCase()
 	.refine((value) => value === 'true' || value === 'false');
 
-const viewSchema = z.string().toLowerCase().trim().min(1).pipe(VIEW_TYPE);
+const viewSchema = zod.string().toLowerCase().trim().min(1).pipe(VIEW_TYPE);
 
-const categoryIdSchema = z
+const categoryIdSchema = zod
 	.string()
 	.trim()
 	.min(1)
@@ -33,21 +33,21 @@ const categoryIdSchema = z
 		return isValidIdNumber(parsed);
 	}, 'invalid category ID');
 
-const endDateSchema = z
+const endDateSchema = zod
 	.string()
 	.trim()
 	.min(1)
 	.refine((value) => isValidDateFormat(value), 'invalid `endDate` parameter');
 
-const entityNameSchema = z.string().trim().min(1);
+const entityNameSchema = zod.string().trim().min(1);
 
-const organizationSchema = z.string().trim().min(1);
+const organizationSchema = zod.string().trim().min(1);
 
-const pageSizeSchema = z.string().superRefine((value, ctx) => {
+const pageSizeSchema = zod.string().superRefine((value, ctx) => {
 	const parsed = parseInt(value);
 	if (isNaN(parsed)) {
 		ctx.addIssue({
-			code: z.ZodIssueCode.invalid_type,
+			code: zod.ZodIssueCode.invalid_type,
 			expected: 'number',
 			received: 'nan',
 		});
@@ -55,7 +55,7 @@ const pageSizeSchema = z.string().superRefine((value, ctx) => {
 
 	if (parsed < 1) {
 		ctx.addIssue({
-			code: z.ZodIssueCode.too_small,
+			code: zod.ZodIssueCode.too_small,
 			minimum: 1,
 			inclusive: true,
 			type: 'number',
@@ -63,22 +63,22 @@ const pageSizeSchema = z.string().superRefine((value, ctx) => {
 	}
 });
 
-const indexIntegerSchema = z.string().superRefine((value, ctx) => {
+const indexIntegerSchema = zod.string().superRefine((value, ctx) => {
 	const parsed = parseInt(value);
 	if (isNaN(parsed)) {
 		ctx.addIssue({
-			code: z.ZodIssueCode.invalid_type,
+			code: zod.ZodIssueCode.invalid_type,
 			expected: 'number',
 			received: 'nan',
 		});
 	}
 });
 
-const positiveInteger = z.string().superRefine((value, ctx) => {
+const positiveInteger = zod.string().superRefine((value, ctx) => {
 	const parsed = parseInt(value);
 	if (isNaN(parsed)) {
 		ctx.addIssue({
-			code: z.ZodIssueCode.invalid_type,
+			code: zod.ZodIssueCode.invalid_type,
 			expected: 'number',
 			received: 'nan',
 		});
@@ -86,7 +86,7 @@ const positiveInteger = z.string().superRefine((value, ctx) => {
 
 	if (parsed < 1) {
 		ctx.addIssue({
-			code: z.ZodIssueCode.too_small,
+			code: zod.ZodIssueCode.too_small,
 			minimum: 1,
 			inclusive: true,
 			type: 'number',
@@ -94,7 +94,7 @@ const positiveInteger = z.string().superRefine((value, ctx) => {
 	}
 });
 
-const sqonSchema = z.custom<SQON>((value) => {
+const sqonSchema = zod.custom<SQON>((value) => {
 	try {
 		parseSQON(value);
 		return true;
@@ -103,19 +103,19 @@ const sqonSchema = z.custom<SQON>((value) => {
 	}
 }, 'invalid SQON format');
 
-const startDateSchema = z
+const startDateSchema = zod
 	.string()
 	.trim()
 	.min(1)
 	.refine((value) => isValidDateFormat(value), 'invalid `startDate` parameter');
 
-const submissionActionTypeSchema = z
+const submissionActionTypeSchema = zod
 	.string()
 	.trim()
 	.min(1)
 	.refine((value) => isSubmissionActionTypeValid(value), 'invalid Submission Action Type');
 
-const submissionIdSchema = z
+const submissionIdSchema = zod
 	.string()
 	.trim()
 	.min(1)
@@ -124,7 +124,7 @@ const submissionIdSchema = z
 		return isValidIdNumber(parsed);
 	}, 'invalid submission ID');
 
-const migrationIdSchema = z
+const migrationIdSchema = zod
 	.string()
 	.trim()
 	.min(1)
@@ -133,31 +133,31 @@ const migrationIdSchema = z
 		return isValidIdNumber(parsed);
 	}, 'invalid migration ID');
 
-const stringNotEmpty = z.string().trim().min(1);
+const stringNotEmpty = zod.string().trim().min(1);
 
 // Common Category Path Params
 export interface CategoryPathParams extends ParamsDictionary {
 	categoryId: string;
 }
 
-export const categoryPathParamsSchema = z.object({
+export const categoryPathParamsSchema = zod.object({
 	categoryId: categoryIdSchema,
 });
 
 // Common Category and Organization Path Params
-export const categoryOrganizationPathParamsSchema = z.object({
+export const categoryOrganizationPathParamsSchema = zod.object({
 	categoryId: categoryIdSchema,
 	organization: organizationSchema,
 });
-export type CategoryOrganizationPathParams = z.infer<typeof categoryOrganizationPathParamsSchema>;
+export type CategoryOrganizationPathParams = zod.infer<typeof categoryOrganizationPathParamsSchema>;
 
 // Common Category, Organization, and EntityName Path Params
-export const categoryOrganizationEntityPathParamsSchema = z.object({
+export const categoryOrganizationEntityPathParamsSchema = zod.object({
 	categoryId: categoryIdSchema,
 	organizationId: organizationSchema,
 	entityName: entityNameSchema,
 });
-export type CategoryOrganizationEntityPathParams = z.infer<typeof categoryOrganizationEntityPathParamsSchema>;
+export type CategoryOrganizationEntityPathParams = zod.infer<typeof categoryOrganizationEntityPathParamsSchema>;
 
 // Common Submission Path Params
 
@@ -165,7 +165,7 @@ export interface submissionIdPathParam extends ParamsDictionary {
 	submissionId: string;
 }
 
-const submissionIdPathParamSchema = z.object({
+const submissionIdPathParamSchema = zod.object({
 	submissionId: submissionIdSchema,
 });
 
@@ -174,7 +174,7 @@ export interface migrationIdPathParam extends ParamsDictionary {
 	migrationId: string;
 }
 
-const migrationIdPathParamSchema = z.object({
+const migrationIdPathParamSchema = zod.object({
 	migrationId: migrationIdSchema,
 });
 
@@ -185,7 +185,7 @@ export interface PaginationQueryParams extends ParsedQs {
 	pageSize?: string;
 }
 
-const paginationQuerySchema = z.object({
+const paginationQuerySchema = zod.object({
 	page: positiveInteger.optional(),
 	pageSize: pageSizeSchema.optional(),
 });
@@ -200,7 +200,7 @@ export interface AuditQueryParams extends ParsedQs {
 	endDate?: string;
 }
 
-const auditQuerySchema = z
+const auditQuerySchema = zod
 	.object({
 		entityName: entityNameSchema.optional(),
 		eventType: auditEventTypeSchema.optional(),
@@ -243,13 +243,13 @@ export const dictionaryRegisterRequestSchema: RequestValidation<
 	DictionaryRegisterQueryParams,
 	ParamsDictionary
 > = {
-	body: z.object({
+	body: zod.object({
 		categoryName: stringNotEmpty,
 		dictionaryName: stringNotEmpty,
 		dictionaryVersion: stringNotEmpty,
-		defaultCentricEntity: entityNameSchema.or(z.literal('')).optional(),
+		defaultCentricEntity: entityNameSchema.or(zod.literal('')).optional(),
 	}),
-	query: z.object({
+	query: zod.object({
 		force: booleanSchema.default('false'),
 	}),
 };
@@ -273,10 +273,10 @@ export interface MigrationDataQueryParams extends PaginationQueryParams {
 
 export const migrationDataRequestSchema: RequestValidation<object, MigrationDataQueryParams, migrationIdPathParam> = {
 	pathParams: migrationIdPathParamSchema,
-	query: z
+	query: zod
 		.object({
-			entityNames: z.union([entityNameSchema, entityNameSchema.array()]).optional(),
-			organizations: z.union([organizationSchema, organizationSchema.array()]).optional(),
+			entityNames: zod.union([entityNameSchema, entityNameSchema.array()]).optional(),
+			organizations: zod.union([organizationSchema, organizationSchema.array()]).optional(),
 			isInvalid: booleanSchema.default('false'),
 		})
 		.merge(paginationQuerySchema),
@@ -295,7 +295,7 @@ export const submissionsByCategoryRequestSchema: RequestValidation<
 	SubmissionsByCategoryQueryParams,
 	CategoryPathParams
 > = {
-	query: z.object({
+	query: zod.object({
 		onlyActive: booleanSchema.default('false'),
 		organization: organizationSchema.optional(),
 		username: stringNotEmpty.optional(),
@@ -316,10 +316,10 @@ export const submissionDetailsRequestSchema: RequestValidation<
 	SubmissionsDetailsQueryParams,
 	submissionIdPathParam
 > = {
-	query: z
+	query: zod
 		.object({
-			entityNames: z.union([entityNameSchema, entityNameSchema.array()]).optional(),
-			actionTypes: z.union([submissionActionTypeSchema, submissionActionTypeSchema.array()]).optional(),
+			entityNames: zod.union([entityNameSchema, entityNameSchema.array()]).optional(),
+			actionTypes: zod.union([submissionActionTypeSchema, submissionActionTypeSchema.array()]).optional(),
 		})
 		.merge(paginationQuerySchema),
 	pathParams: submissionIdPathParamSchema,
@@ -339,7 +339,7 @@ export interface submissionCommitPathParams extends ParamsDictionary {
 }
 
 export const submissionCommitRequestSchema: RequestValidation<object, ParsedQs, submissionCommitPathParams> = {
-	pathParams: z.object({
+	pathParams: zod.object({
 		categoryId: categoryIdSchema,
 		submissionId: submissionIdSchema,
 	}),
@@ -355,7 +355,7 @@ export const submissionDeleteRequestSchema: RequestValidation<
 	submissionIdPathParam
 > = {
 	pathParams: submissionIdPathParamSchema,
-	query: z.object({
+	query: zod.object({
 		force: booleanSchema.default('false'),
 	}),
 };
@@ -375,47 +375,48 @@ export const submissionDeleteEntityNameRequestSchema: RequestValidation<
 	SubmissionDeleteEntityNameQueryParams,
 	SubmissionDeleteEntityNameParams
 > = {
-	query: z.object({
+	query: zod.object({
 		entityName: entityNameSchema,
 		index: indexIntegerSchema.optional(),
 	}),
-	pathParams: z.object({
+	pathParams: zod.object({
 		actionType: submissionActionTypeSchema,
 		submissionId: submissionIdSchema,
 	}),
 };
 
-const uploadSubmissionQueryParams = z.object({
+const uploadSubmissionQueryParams = zod.object({
 	entityName: entityNameSchema,
 	organization: organizationSchema,
 });
 
-export type UploadSubmissionQueryParams = z.infer<typeof uploadSubmissionQueryParams>;
+export type UploadSubmissionQueryParams = zod.infer<typeof uploadSubmissionQueryParams>;
 
-const submissionUploadFilesQueryParams = z.object({
+const submissionUploadFilesQueryParams = zod.object({
 	organization: organizationSchema,
+	sync: zod.enum(['true', 'false']).optional(),
 });
 
-export type SubmissionUploadFilesQueryParams = z.infer<typeof submissionUploadFilesQueryParams>;
+export type SubmissionUploadFilesQueryParams = zod.infer<typeof submissionUploadFilesQueryParams>;
 
-export const filenameEntityPair = z.object({
-	filename: z.string(),
-	entity: z.string(),
+export const filenameEntityPair = zod.object({
+	filename: zod.string(),
+	entity: zod.string(),
 });
 
-export type FilenameEntityPair = z.infer<typeof filenameEntityPair>;
+export type FilenameEntityPair = zod.infer<typeof filenameEntityPair>;
 
-const dataRecordValueSchema = z.union([
-	z.string(),
-	z.number(),
-	z.boolean(),
-	z.array(z.string()),
-	z.array(z.number()),
-	z.array(z.boolean()),
-	z.undefined(),
+const dataRecordValueSchema = zod.union([
+	zod.string(),
+	zod.number(),
+	zod.boolean(),
+	zod.array(zod.string()),
+	zod.array(zod.number()),
+	zod.array(zod.boolean()),
+	zod.undefined(),
 ]);
 
-const dataRecordSchema = z.record(dataRecordValueSchema);
+const dataRecordSchema = zod.record(dataRecordValueSchema);
 
 export const uploadSubmissionRequestSchema: RequestValidation<
 	FilenameEntityPair[] | undefined,
@@ -429,7 +430,7 @@ export const uploadSubmissionRequestSchema: RequestValidation<
 	// When no text fields are sent, req.body is an empty null-prototype object {}.
 	// The preprocess step extracts and parses the fileEntityMap field when present,
 	// and coerces all other values (empty object, non-array) to undefined.
-	body: z.preprocess((value: unknown) => {
+	body: zod.preprocess((value: unknown) => {
 		if (Array.isArray(value)) {
 			return value;
 		}
@@ -452,7 +453,7 @@ export const uploadSubmissionRequestSchema: RequestValidation<
 		} catch {
 			return undefined;
 		}
-	}, z.array(filenameEntityPair).optional()),
+	}, zod.array(filenameEntityPair).optional()),
 };
 
 export const uploadSingleEntitySubmissionDataRequestSchema: RequestValidation<
@@ -473,7 +474,7 @@ export interface DataDeleteBySystemIdPathParams extends ParamsDictionary {
 }
 
 export const dataDeleteBySystemIdRequestSchema: RequestValidation<object, ParsedQs, DataDeleteBySystemIdPathParams> = {
-	pathParams: z.object({
+	pathParams: zod.object({
 		systemId: stringNotEmpty,
 		categoryId: categoryIdSchema,
 	}),
@@ -490,7 +491,7 @@ export const editSingleEntityRequestSchema: RequestValidation<
 	UploadSubmissionQueryParams,
 	CategoryPathParams
 > = {
-	body: z.record(z.unknown()).array(),
+	body: zod.record(zod.unknown()).array(),
 	query: uploadSubmissionQueryParams,
 	pathParams: categoryPathParamsSchema,
 };
@@ -505,16 +506,16 @@ export interface GetDataQueryParams extends ParsedQs {
 }
 
 export const dataGetByCategoryRequestSchema: RequestValidation<object, DataQueryParams, CategoryPathParams> = {
-	query: z
+	query: zod
 		.object({
-			entityName: z.union([entityNameSchema, entityNameSchema.array()]).optional(),
+			entityName: zod.union([entityNameSchema, entityNameSchema.array()]).optional(),
 			view: viewSchema.optional(),
 		})
 		.merge(paginationQuerySchema)
 		.superRefine((data, ctx) => {
 			if (data.view === VIEW_TYPE.Values.compound && data.entityName && data.entityName?.length > 0) {
 				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
+					code: zod.ZodIssueCode.custom,
 					message: 'is incompatible with `compound` view',
 					path: ['entityName'],
 				});
@@ -528,16 +529,16 @@ export const dataGetByOrganizationRequestSchema: RequestValidation<
 	DataQueryParams,
 	CategoryOrganizationPathParams
 > = {
-	query: z
+	query: zod
 		.object({
-			entityName: z.union([entityNameSchema, entityNameSchema.array()]).optional(),
+			entityName: zod.union([entityNameSchema, entityNameSchema.array()]).optional(),
 			view: viewSchema.optional(),
 		})
 		.merge(paginationQuerySchema)
 		.superRefine((data, ctx) => {
 			if (data.view === VIEW_TYPE.Values.compound && data.entityName && data.entityName?.length > 0) {
 				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
+					code: zod.ZodIssueCode.custom,
 					message: 'is incompatible with `compound` view',
 					path: ['entityName'],
 				});
@@ -548,9 +549,9 @@ export const dataGetByOrganizationRequestSchema: RequestValidation<
 
 export const dataGetByQueryRequestSchema: RequestValidation<object, DataQueryParams, CategoryOrganizationPathParams> = {
 	body: sqonSchema,
-	query: z
+	query: zod
 		.object({
-			entityName: z.union([entityNameSchema, entityNameSchema.array()]).optional(),
+			entityName: zod.union([entityNameSchema, entityNameSchema.array()]).optional(),
 		})
 		.merge(paginationQuerySchema),
 	pathParams: categoryOrganizationPathParamsSchema,
@@ -566,24 +567,24 @@ export const DataGetBySystemIdRequestSchema: RequestValidation<
 	GetDataQueryParams,
 	DataGetBySystemIdPathParams
 > = {
-	query: z.object({
+	query: zod.object({
 		view: viewSchema.optional(),
 	}),
-	pathParams: z.object({
+	pathParams: zod.object({
 		systemId: stringNotEmpty,
 		categoryId: categoryIdSchema,
 	}),
 };
 
 export const downloadDataFileTemplatesSchema = {
-	query: z.object({
-		fileType: z.enum(['csv', 'tsv']).optional(),
+	query: zod.object({
+		fileType: zod.enum(['csv', 'tsv']).optional(),
 	}),
-	pathParams: z.object({
+	pathParams: zod.object({
 		categoryId: categoryIdSchema,
 	}),
 };
-export const validationPathParamsSchema = z.object({
+export const validationPathParamsSchema = zod.object({
 	categoryId: categoryIdSchema,
 	entityName: entityNameSchema,
 });
@@ -593,7 +594,7 @@ export interface ValidationPathParams extends ParamsDictionary {
 	entityName: string;
 }
 
-const validationQuerySchema = z.object({
+const validationQuerySchema = zod.object({
 	organization: organizationSchema,
 	value: stringNotEmpty,
 });

--- a/packages/data-provider/src/utils/submissionUtils.spec.ts
+++ b/packages/data-provider/src/utils/submissionUtils.spec.ts
@@ -1,0 +1,139 @@
+import { expect } from 'chai';
+import { writeFileSync } from 'fs';
+import { describe, it } from 'mocha';
+import { join } from 'path';
+import { Readable } from 'stream';
+import { tmpdir } from 'os';
+
+import { type Schema } from '@overture-stack/lectern-client';
+
+import { submissionInsertDataFromFiles } from './submissionUtils.js';
+import { type FileSchemaMap } from './types.js';
+
+const makeFile = (path: string, originalname: string): Express.Multer.File => ({
+	path,
+	originalname,
+	buffer: Buffer.alloc(0),
+	destination: '',
+	encoding: 'utf-8',
+	fieldname: 'files',
+	filename: '',
+	mimetype: 'text/tab-separated-values',
+	size: 0,
+	stream: new Readable(),
+});
+
+const minimalSchema = (name: string): Schema => ({
+	name,
+	description: '',
+	restrictions: {},
+	fields: [
+		{
+			name: 'item_id',
+			valueType: 'string',
+			description: '',
+			restrictions: {},
+		},
+	],
+});
+
+// Schema with an integer field — passing a non-numeric string causes a parse type error.
+const integerSchema = (name: string): Schema => ({
+	name,
+	description: '',
+	restrictions: {},
+	fields: [
+		{
+			name: 'count',
+			valueType: 'integer',
+			description: '',
+			restrictions: {},
+		},
+	],
+});
+
+const writeTsv = (rows: string[][]): string => {
+	const path = join(tmpdir(), `lyric-test-${process.hrtime.bigint()}.tsv`);
+	writeFileSync(path, rows.map((r) => r.join('\t')).join('\n'));
+	return path;
+};
+
+describe('submissionInsertDataFromFiles', () => {
+	it('returns status ok for a file that parses and validates successfully', async () => {
+		const path = writeTsv([['item_id'], ['A']]);
+		const fileSchemaMap: FileSchemaMap = {
+			items: { files: [makeFile(path, 'items.tsv')], schema: minimalSchema('items') },
+		};
+
+		const { fileResults } = await submissionInsertDataFromFiles(fileSchemaMap);
+
+		expect(fileResults).to.have.length(1);
+		expect(fileResults[0]?.status).to.equal('ok');
+		expect(fileResults[0]?.fileName).to.equal('items.tsv');
+	});
+
+	it('returns status invalid for a file with schema validation failures', async () => {
+		const path = writeTsv([['count'], ['not-a-number']]); // non-numeric value for an integer field
+		const fileSchemaMap: FileSchemaMap = {
+			items: { files: [makeFile(path, 'items.tsv')], schema: integerSchema('items') },
+		};
+
+		const { fileResults } = await submissionInsertDataFromFiles(fileSchemaMap);
+
+		expect(fileResults).to.have.length(1);
+		const result = fileResults[0];
+		expect(result?.status).to.equal('invalid');
+		if (result?.status === 'invalid') {
+			expect(result.parseErrors).to.have.length.greaterThan(0);
+		}
+	});
+
+	it('returns status error for a file that cannot be read', async () => {
+		const fileSchemaMap: FileSchemaMap = {
+			items: { files: [makeFile('/nonexistent/path/items.tsv', 'items.tsv')], schema: minimalSchema('items') },
+		};
+
+		const { fileResults } = await submissionInsertDataFromFiles(fileSchemaMap);
+
+		expect(fileResults).to.have.length(1);
+		const result = fileResults[0];
+		expect(result?.status).to.equal('error');
+		if (result?.status === 'error') {
+			expect(result.streamError).to.be.a('string').and.not.be.empty;
+		}
+	});
+
+	it('processes remaining files when one file fails (fault isolation)', async () => {
+		const validPath = writeTsv([['item_id'], ['A']]);
+		const fileSchemaMap: FileSchemaMap = {
+			items: {
+				files: [
+					makeFile('/nonexistent/path/missing.tsv', 'missing.tsv'),
+					makeFile(validPath, 'valid.tsv'),
+				],
+				schema: minimalSchema('items'),
+			},
+		};
+
+		const { fileResults } = await submissionInsertDataFromFiles(fileSchemaMap);
+
+		expect(fileResults).to.have.length(2);
+		expect(fileResults.find((r) => r.fileName === 'missing.tsv')?.status).to.equal('error');
+		expect(fileResults.find((r) => r.fileName === 'valid.tsv')?.status).to.equal('ok');
+	});
+
+	it('accumulates records from multiple successful files for the same entity', async () => {
+		const pathA = writeTsv([['item_id'], ['A']]);
+		const pathB = writeTsv([['item_id'], ['B']]);
+		const schema = minimalSchema('items');
+		const fileSchemaMap: FileSchemaMap = {
+			items: { files: [makeFile(pathA, 'a.tsv'), makeFile(pathB, 'b.tsv')], schema },
+		};
+
+		const { data, fileResults } = await submissionInsertDataFromFiles(fileSchemaMap);
+
+		expect(fileResults).to.have.length(2);
+		expect(fileResults.every((r) => r.status === 'ok')).to.be.true;
+		expect(data['items']?.records).to.have.length(2);
+	});
+});

--- a/packages/data-provider/src/utils/submissionUtils.ts
+++ b/packages/data-provider/src/utils/submissionUtils.ts
@@ -833,10 +833,11 @@ export const segregateFieldChangeRecords = (
 };
 
 /** Per-file outcome from `submissionInsertDataFromFiles`. */
-export type FileParseResult =
-	| { status: 'ok'; fileName: string; entityName: string }
-	| { status: 'invalid'; fileName: string; entityName: string; parseErrors: ParseSchemaError[] }
-	| { status: 'error'; fileName: string; entityName: string; streamError: string };
+export type FileParseResult = { fileName: string; entityName: string } & (
+	| { status: 'ok' }
+	| { status: 'invalid'; parseErrors: ParseSchemaError[] }
+	| { status: 'error'; streamError: string }
+);
 
 /** Return type of `submissionInsertDataFromFiles`. */
 export type FileInsertResult = {

--- a/packages/data-provider/src/utils/submissionUtils.ts
+++ b/packages/data-provider/src/utils/submissionUtils.ts
@@ -6,6 +6,7 @@ import {
 	Dictionary as SchemasDictionary,
 	DictionaryValidationError,
 	parse,
+	type ParseSchemaError,
 	Schema,
 	TestResult,
 	validate,
@@ -831,32 +832,50 @@ export const segregateFieldChangeRecords = (
 	);
 };
 
+/** Per-file outcome from `submissionInsertDataFromFiles`. */
+export type FileParseResult =
+	| { status: 'ok'; fileName: string; entityName: string }
+	| { status: 'invalid'; fileName: string; entityName: string; parseErrors: ParseSchemaError[] }
+	| { status: 'error'; fileName: string; entityName: string; streamError: string };
+
+/** Return type of `submissionInsertDataFromFiles`. */
+export type FileInsertResult = {
+	data: Record<string, SubmissionInsertData>;
+	fileResults: FileParseResult[];
+};
+
 /**
- * Construct a SubmissionInsertData object per each file returning a Record type based on entityName
- * @param {FileSchemaMap} fileSchemaPairs
- * @returns {Promise<Record<string, SubmissionInsertData>>}
+ * Parses all files in the schema map into insertion records.
+ * Each file is processed independently: a stream or parse failure on one file is captured and
+ * reported without interrupting processing of the remaining files.
  */
-export const submissionInsertDataFromFiles = async (
-	fileSchemaMap: FileSchemaMap,
-): Promise<Record<string, SubmissionInsertData>> => {
-	const output: Record<string, SubmissionInsertData> = {};
+export const submissionInsertDataFromFiles = async (fileSchemaMap: FileSchemaMap): Promise<FileInsertResult> => {
+	const data: Record<string, SubmissionInsertData> = {};
+	const fileResults: FileParseResult[] = [];
 
 	for (const [entityName, { files, schema }] of Object.entries(fileSchemaMap)) {
 		for (const file of files) {
-			const outputEntityValue = output[schema.name] ?? {
-				batchName: entityName,
-				records: [],
-			};
-			const parsedFileData = await readTextFile(file, schema);
-			// TODO: This doesn't handle parsedFileData.errors, when present.
-
-			outputEntityValue.records.push(...parsedFileData.records);
-
-			output[schema.name] = outputEntityValue;
+			try {
+				const parsedFileData = await readTextFile(file, schema);
+				const existing = data[schema.name] ?? { batchName: entityName, records: [] };
+				data[schema.name] = { ...existing, records: [...existing.records, ...parsedFileData.records] };
+				fileResults.push(
+					parsedFileData.errors.length > 0
+						? { status: 'invalid', fileName: file.originalname, entityName, parseErrors: parsedFileData.errors }
+						: { status: 'ok', fileName: file.originalname, entityName },
+				);
+			} catch (err) {
+				fileResults.push({
+					status: 'error',
+					fileName: file.originalname,
+					entityName,
+					streamError: err instanceof Error ? err.message : String(err),
+				});
+			}
 		}
 	}
 
-	return output;
+	return { data, fileResults };
 };
 
 /**

--- a/packages/data-provider/src/utils/types.ts
+++ b/packages/data-provider/src/utils/types.ts
@@ -121,6 +121,7 @@ export interface SubmitDataResult {
  */
 export interface SubmitFileResult extends SubmitDataResult {
 	batchErrors: BatchError[];
+	fileResults: import('./submissionUtils.js').FileParseResult[];
 	inProcessEntities: string[];
 }
 

--- a/packages/data-provider/test/unit/utils/schemas.spec.ts
+++ b/packages/data-provider/test/unit/utils/schemas.spec.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'mocha';
 import { uploadSubmissionRequestSchema } from '../../../src/utils/schemas.js';
 
 const bodySchema = uploadSubmissionRequestSchema.body;
+const querySchema = uploadSubmissionRequestSchema.query;
 
 describe('uploadSubmissionRequestSchema body', () => {
 	/**
@@ -64,5 +65,27 @@ describe('uploadSubmissionRequestSchema body', () => {
 				{ filename: 'b.tsv', entity: 'sample' },
 			],
 		});
+	});
+});
+
+describe('uploadSubmissionRequestSchema query', () => {
+	it('accepts a valid organization with no sync param', () => {
+		const result = querySchema?.safeParse({ organization: 'test-org' });
+		expect(result?.success).to.be.true;
+	});
+
+	it('accepts sync=true', () => {
+		const result = querySchema?.safeParse({ organization: 'test-org', sync: 'true' });
+		expect(result?.success).to.be.true;
+	});
+
+	it('accepts sync=false', () => {
+		const result = querySchema?.safeParse({ organization: 'test-org', sync: 'false' });
+		expect(result?.success).to.be.true;
+	});
+
+	it('rejects sync with a value outside the allowed enum', () => {
+		const result = querySchema?.safeParse({ organization: 'test-org', sync: 'yes' });
+		expect(result?.success).to.be.false;
 	});
 });


### PR DESCRIPTION
Each file in a batch submission is now processed independently: a stream error or schema validation failure on one file is caught and reported without blocking the remaining files.

Parse results use a three-state discriminator (ok/invalid/error) and are returned synchronously in the API response, so callers know immediately which files failed and why.

Structured logging separates human-readable console output (key=value) from a JSON file transport (LOG_JSON env var) for log aggregator ingestion. Field names and line numbers are logged for schema errors; field values are not (OWASP A03).

Bonus: Adds optional sync=false query parameter to the file upload endpoint to allow background parsing for very large batches; when omitted or true, behaviour is synchronous and unchanged from the existing default.

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [x] **Formatting**
  - Code follows the project style guide
  - Automated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
